### PR TITLE
Add library screen import

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'screens/library_screen.dart';
 
 void main() => runApp(const ManaReaderApp());
 


### PR DESCRIPTION
## Summary
- import `LibraryScreen` in `main.dart`

## Testing
- `flutter analyze` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6887e166f3b483268ab60f2388e8c22d