### PR TITLE
Add book CRUD and history functions

### DIFF
--- a/test/db_helper_test.dart
+++ b/test/db_helper_test.dart
@@ -1,0 +1,46 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mana_reader/database/db_helper.dart';
+import 'package:mana_reader/models/book_model.dart';
+
+void main() {
+  final db = DbHelper.instance;
+
+  test('insert and fetch book', () async {
+    final id = await db.insertBook(
+      BookModel(title: 'Title', path: '/path', language: 'en'),
+    );
+    final book = await db.fetchBook(id);
+    expect(book?.title, 'Title');
+  });
+
+  test('update book metadata', () async {
+    final id = await db.insertBook(
+      BookModel(title: 'Old', path: '/old', language: 'en'),
+    );
+    await db.updateBook(id, title: 'New', path: '/new', tags: ['a']);
+    final book = await db.fetchBook(id);
+    expect(book?.title, 'New');
+    expect(book?.path, '/new');
+    expect(book?.tags, ['a']);
+  });
+
+  test('delete book', () async {
+    final id = await db.insertBook(
+      BookModel(title: 'Delete', path: '/d', language: 'en'),
+    );
+    final rows = await db.deleteBook(id);
+    expect(rows, 1);
+    final book = await db.fetchBook(id);
+    expect(book, isNull);
+  });
+
+  test('history logging', () async {
+    final id = await db.insertBook(
+      BookModel(title: 'History', path: '/h', language: 'en'),
+    );
+    await db.updateProgress(id, 5);
+    final history = await db.fetchHistory(id);
+    expect(history.length, 1);
+    expect(history.first['page'], 5);
+  });
+}


### PR DESCRIPTION
## Summary
- extend the `DbHelper` class with single-book fetch, metadata update, deletion, and reading history support
- log progress updates into a new `history` table
- add tests covering CRUD and history operations

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6887e8f57d1483268e50dae66fb19e49