### PR TITLE
Add library filters and reader screen

### DIFF
--- a/lib/database/db_helper.dart
+++ b/lib/database/db_helper.dart
@@ -32,6 +32,7 @@ class DbHelper {
             id INTEGER PRIMARY KEY AUTOINCREMENT,
             title TEXT,
             path TEXT,
+            author TEXT,
             language TEXT,
             tags TEXT,
             last_page INTEGER
@@ -46,10 +47,55 @@ class DbHelper {
     return db.insert('books', book.toMap());
   }
 
-  Future<List<BookModel>> fetchBooks() async {
+  Future<List<BookModel>> fetchBooks({
+    List<String>? tags,
+    String? author,
+    bool? unread,
+  }) async {
     final db = await database;
-    final maps = await db.query('books');
+    final where = <String>[];
+    final args = <dynamic>[];
+    if (tags != null && tags.isNotEmpty) {
+      for (final tag in tags) {
+        where.add('tags LIKE ?');
+        args.add('%' + tag + '%');
+      }
+    }
+    if (author != null && author.isNotEmpty) {
+      where.add('author = ?');
+      args.add(author);
+    }
+    if (unread != null) {
+      where.add(unread ? 'last_page = 0' : 'last_page > 0');
+    }
+    final maps = await db.query(
+      'books',
+      where: where.isEmpty ? null : where.join(' AND '),
+      whereArgs: args,
+    );
     return maps.map((e) => BookModel.fromMap(e)).toList();
+  }
+
+  Future<List<String>> fetchAllAuthors() async {
+    final db = await database;
+    final maps = await db.rawQuery(
+      'SELECT DISTINCT author FROM books WHERE author IS NOT NULL AND author != ""',
+    );
+    return maps.map((e) => e['author'] as String).toList();
+  }
+
+  Future<List<String>> fetchAllTags() async {
+    final db = await database;
+    final maps = await db.query('books', columns: ['tags']);
+    final set = <String>{};
+    for (final map in maps) {
+      final tagStr = map['tags'] as String? ?? '';
+      set.addAll(tagStr
+          .split(',')
+          .map((e) => e.trim())
+          .where((element) => element.isNotEmpty));
+    }
+    return set.toList();
   }
 
   Future<void> updateProgress(int id, int page) async {

--- a/lib/models/book_model.dart
+++ b/lib/models/book_model.dart
@@ -2,6 +2,7 @@ class BookModel {
   final int? id;
   final String title;
   final String path;
+  final String author;
   final String language;
   final List<String> tags;
   final int lastPage;
@@ -10,6 +11,7 @@ class BookModel {
     this.id,
     required this.title,
     required this.path,
+    this.author = '',
     required this.language,
     this.tags = const [],
     this.lastPage = 0,
@@ -20,6 +22,7 @@ class BookModel {
       'id': id,
       'title': title,
       'path': path,
+      'author': author,
       'language': language,
       'tags': tags.join(','),
       'last_page': lastPage,
@@ -31,6 +34,7 @@ class BookModel {
       id: map['id'] as int?,
       title: map['title'] as String,
       path: map['path'] as String,
+      author: map['author'] as String? ?? '',
       language: map['language'] as String? ?? 'unknown',
       tags: (map['tags'] as String? ?? '').split(',').where((t) => t.isNotEmpty).toList(),
       lastPage: map['last_page'] as int? ?? 0,

--- a/lib/screens/library_screen.dart
+++ b/lib/screens/library_screen.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import '../database/db_helper.dart';
 import '../models/book_model.dart';
+import 'reader_screen.dart';
 
 /// Displays the list of imported books.
 class LibraryScreen extends StatefulWidget {
@@ -12,17 +13,51 @@ class LibraryScreen extends StatefulWidget {
 
 class _LibraryScreenState extends State<LibraryScreen> {
   late Future<List<BookModel>> _books;
+  List<String> _tags = [];
+  List<String> _authors = [];
+  String? _selectedTag;
+  String? _selectedAuthor;
+  bool _showUnread = false;
+  bool _isGrid = true;
 
   @override
   void initState() {
     super.initState();
-    _books = DbHelper.instance.fetchBooks();
+    _loadBooks();
+    _initFilters();
+  }
+
+  void _loadBooks() {
+    setState(() {
+      _books = DbHelper.instance.fetchBooks(
+        tags: _selectedTag != null ? [_selectedTag!] : null,
+        author: _selectedAuthor,
+        unread: _showUnread ? true : null,
+      );
+    });
+  }
+
+  Future<void> _initFilters() async {
+    final tags = await DbHelper.instance.fetchAllTags();
+    final authors = await DbHelper.instance.fetchAllAuthors();
+    setState(() {
+      _tags = tags;
+      _authors = authors;
+    });
   }
 
   @override
   Widget build(BuildContext context) {
     return Scaffold(
-      appBar: AppBar(title: const Text('Library')),
+      appBar: AppBar(
+        title: const Text('Library'),
+        actions: [
+          IconButton(
+            icon: Icon(_isGrid ? Icons.view_list : Icons.grid_on),
+            onPressed: () => setState(() => _isGrid = !_isGrid),
+          ),
+        ],
+      ),
       body: FutureBuilder<List<BookModel>>(
         future: _books,
         builder: (context, snapshot) {
@@ -33,29 +68,119 @@ class _LibraryScreenState extends State<LibraryScreen> {
           if (books.isEmpty) {
             return const Center(child: Text('No books imported'));
           }
-          return GridView.builder(
-            padding: const EdgeInsets.all(8),
-            gridDelegate: const SliverGridDelegateWithFixedCrossAxisCount(
-              crossAxisCount: 3,
-              childAspectRatio: 0.7,
-              mainAxisSpacing: 8,
-              crossAxisSpacing: 8,
-            ),
-            itemCount: books.length,
-            itemBuilder: (context, index) {
-              final book = books[index];
-              return GestureDetector(
-                onTap: () {},
-                child: Container(
-                  color: Colors.grey.shade800,
-                  alignment: Alignment.center,
-                  child: Text(
-                    book.title,
-                    textAlign: TextAlign.center,
+          Widget listWidget;
+          if (_isGrid) {
+            listWidget = GridView.builder(
+              padding: const EdgeInsets.all(8),
+              gridDelegate: const SliverGridDelegateWithFixedCrossAxisCount(
+                crossAxisCount: 3,
+                childAspectRatio: 0.7,
+                mainAxisSpacing: 8,
+                crossAxisSpacing: 8,
+              ),
+              itemCount: books.length,
+              itemBuilder: (context, index) {
+                final book = books[index];
+                return GestureDetector(
+                  onTap: () => Navigator.push(
+                    context,
+                    MaterialPageRoute(
+                      builder: (_) => ReaderScreen(book: book),
+                    ),
+                  ),
+                  child: Container(
+                    color: Colors.grey.shade800,
+                    alignment: Alignment.center,
+                    child: Text(
+                      book.title,
+                      textAlign: TextAlign.center,
+                    ),
+                  ),
+                );
+              },
+            );
+          } else {
+            listWidget = ListView.builder(
+              padding: const EdgeInsets.all(8),
+              itemCount: books.length,
+              itemBuilder: (context, index) {
+                final book = books[index];
+                return ListTile(
+                  title: Text(book.title),
+                  subtitle: Text(book.author),
+                  onTap: () => Navigator.push(
+                    context,
+                    MaterialPageRoute(
+                      builder: (_) => ReaderScreen(book: book),
+                    ),
+                  ),
+                );
+              },
+            );
+          }
+
+          return Column(
+            children: [
+              if (_tags.isNotEmpty || _authors.isNotEmpty)
+                Padding(
+                  padding: const EdgeInsets.all(8.0),
+                  child: Row(
+                    children: [
+                      if (_tags.isNotEmpty)
+                        DropdownButton<String?>(
+                          hint: const Text('Tag'),
+                          value: _selectedTag,
+                          items: [
+                            const DropdownMenuItem<String?>(
+                                value: null, child: Text('All')),
+                            ..._tags.map(
+                              (e) => DropdownMenuItem<String?>(
+                                  value: e, child: Text(e)),
+                            ),
+                          ],
+                          onChanged: (value) {
+                            _selectedTag = value;
+                            _loadBooks();
+                          },
+                        ),
+                      const SizedBox(width: 8),
+                      if (_authors.isNotEmpty)
+                        DropdownButton<String?>(
+                          hint: const Text('Author'),
+                          value: _selectedAuthor,
+                          items: [
+                            const DropdownMenuItem<String?>(
+                                value: null, child: Text('All')),
+                            ..._authors.map(
+                              (e) => DropdownMenuItem<String?>(
+                                  value: e, child: Text(e)),
+                            ),
+                          ],
+                          onChanged: (value) {
+                            _selectedAuthor = value;
+                            _loadBooks();
+                          },
+                        ),
+                      const SizedBox(width: 8),
+                      Row(
+                        children: [
+                          Checkbox(
+                            value: _showUnread,
+                            onChanged: (v) {
+                              setState(() {
+                                _showUnread = v ?? false;
+                              });
+                              _loadBooks();
+                            },
+                          ),
+                          const Text('Unread')
+                        ],
+                      )
+                    ],
                   ),
                 ),
-              );
-            },
+              Expanded(child: listWidget),
+            ],
           );
         },
       ),

--- a/lib/screens/reader_screen.dart
+++ b/lib/screens/reader_screen.dart
@@ -1,0 +1,18 @@
+import 'package:flutter/material.dart';
+import '../models/book_model.dart';
+
+class ReaderScreen extends StatelessWidget {
+  final BookModel book;
+
+  const ReaderScreen({super.key, required this.book});
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(title: Text(book.title)),
+      body: Center(
+        child: Text('Reader for ${book.title}'),
+      ),
+    );
+  }
+}


### PR DESCRIPTION
## Summary
- allow list/grid layout toggle and filtering in `LibraryScreen`
- track authors in `BookModel`
- support filtered book queries in `DbHelper`
- basic `ReaderScreen` that opens on tap

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6887e8fa61ec8326aa2189c029ebe80d