### PR TITLE
Add archive importers and simple import UI

### DIFF
--- a/lib/importers/importer.dart
+++ b/lib/importers/importer.dart
@@ -1,0 +1,4 @@
+import "../models/book_model.dart";
+abstract class Importer {
+  Future<BookModel> import(String path);
+}

--- a/lib/importers/importer_factory.dart
+++ b/lib/importers/importer_factory.dart
@@ -1,0 +1,19 @@
+import 'importer.dart';
+import 'zip_importer.dart';
+import 'rar_importer.dart';
+import 'seven_zip_importer.dart';
+
+class ImporterFactory {
+  static Importer fromPath(String path) {
+    final lower = path.toLowerCase();
+    if (lower.endsWith('.cbz') || lower.endsWith('.zip')) {
+      return ZipImporter();
+    } else if (lower.endsWith('.cbr') || lower.endsWith('.rar')) {
+      return RarImporter();
+    } else if (lower.endsWith('.cb7') || lower.endsWith('.7z')) {
+      return SevenZipImporter();
+    } else {
+      throw UnsupportedError('Unsupported archive type');
+    }
+  }
+}

--- a/lib/importers/rar_importer.dart
+++ b/lib/importers/rar_importer.dart
@@ -1,0 +1,57 @@
+import 'dart:io';
+
+import 'package:rar/rar.dart';
+import 'package:path/path.dart' as p;
+import 'package:path_provider/path_provider.dart';
+
+import '../models/book_model.dart';
+import 'importer.dart';
+
+class RarImporter extends Importer {
+  @override
+  Future<BookModel> import(String filePath) async {
+    final baseName = p.basenameWithoutExtension(filePath);
+    final destDir = await _createDestDir(baseName);
+    final result = await Rar.extractRarFile(
+      rarFilePath: filePath,
+      destinationPath: destDir.path,
+    );
+    if (result['success'] != true) {
+      throw Exception(result['message']);
+    }
+    final pages = _collectPages(destDir.path);
+    return BookModel(
+      title: baseName,
+      path: destDir.path,
+      language: 'unknown',
+      pages: pages,
+    );
+  }
+
+  Future<Directory> _createDestDir(String baseName) async {
+    final docs = await getApplicationDocumentsDirectory();
+    final dir = Directory(p.join(docs.path, 'books', baseName));
+    await dir.create(recursive: true);
+    return dir;
+  }
+
+  List<String> _collectPages(String dirPath) {
+    final dir = Directory(dirPath);
+    final pages = dir
+        .listSync(recursive: true)
+        .whereType<File>()
+        .where((f) => _isImage(f.path))
+        .map((f) => f.path)
+        .toList()
+      ..sort();
+    return pages;
+  }
+
+  bool _isImage(String path) {
+    final lower = path.toLowerCase();
+    return lower.endsWith('.jpg') ||
+        lower.endsWith('.jpeg') ||
+        lower.endsWith('.png') ||
+        lower.endsWith('.gif');
+  }
+}

--- a/lib/importers/seven_zip_importer.dart
+++ b/lib/importers/seven_zip_importer.dart
@@ -1,0 +1,53 @@
+import 'dart:io';
+
+import 'package:path/path.dart' as p;
+import 'package:path_provider/path_provider.dart';
+
+import '../models/book_model.dart';
+import 'importer.dart';
+
+class SevenZipImporter extends Importer {
+  @override
+  Future<BookModel> import(String filePath) async {
+    final baseName = p.basenameWithoutExtension(filePath);
+    final destDir = await _createDestDir(baseName);
+    final result = await Process.run('7z', ['x', filePath, '-o${destDir.path}']);
+    if (result.exitCode != 0) {
+      throw Exception(result.stderr);
+    }
+    final pages = _collectPages(destDir.path);
+    return BookModel(
+      title: baseName,
+      path: destDir.path,
+      language: 'unknown',
+      pages: pages,
+    );
+  }
+
+  Future<Directory> _createDestDir(String baseName) async {
+    final docs = await getApplicationDocumentsDirectory();
+    final dir = Directory(p.join(docs.path, 'books', baseName));
+    await dir.create(recursive: true);
+    return dir;
+  }
+
+  List<String> _collectPages(String dirPath) {
+    final dir = Directory(dirPath);
+    final pages = dir
+        .listSync(recursive: true)
+        .whereType<File>()
+        .where((f) => _isImage(f.path))
+        .map((f) => f.path)
+        .toList()
+      ..sort();
+    return pages;
+  }
+
+  bool _isImage(String path) {
+    final lower = path.toLowerCase();
+    return lower.endsWith('.jpg') ||
+        lower.endsWith('.jpeg') ||
+        lower.endsWith('.png') ||
+        lower.endsWith('.gif');
+  }
+}

--- a/lib/importers/zip_importer.dart
+++ b/lib/importers/zip_importer.dart
@@ -1,0 +1,52 @@
+import 'dart:io';
+
+import 'package:archive/archive.dart';
+import 'package:path/path.dart' as p;
+import 'package:path_provider/path_provider.dart';
+
+import '../models/book_model.dart';
+import 'importer.dart';
+
+class ZipImporter extends Importer {
+  @override
+  Future<BookModel> import(String filePath) async {
+    final bytes = await File(filePath).readAsBytes();
+    final archive = ZipDecoder().decodeBytes(bytes);
+    final baseName = p.basenameWithoutExtension(filePath);
+    final destDir = await _createDestDir(baseName);
+    final pages = <String>[];
+    for (final file in archive) {
+      if (file.isFile) {
+        final outPath = p.join(destDir.path, file.name);
+        File(outPath)
+          ..createSync(recursive: true)
+          ..writeAsBytesSync(file.content as List<int>);
+        if (_isImage(file.name)) {
+          pages.add(outPath);
+        }
+      }
+    }
+    pages.sort();
+    return BookModel(
+      title: baseName,
+      path: destDir.path,
+      language: 'unknown',
+      pages: pages,
+    );
+  }
+
+  bool _isImage(String name) {
+    final lower = name.toLowerCase();
+    return lower.endsWith('.jpg') ||
+        lower.endsWith('.jpeg') ||
+        lower.endsWith('.png') ||
+        lower.endsWith('.gif');
+  }
+
+  Future<Directory> _createDestDir(String baseName) async {
+    final docs = await getApplicationDocumentsDirectory();
+    final dir = Directory(p.join(docs.path, 'books', baseName));
+    await dir.create(recursive: true);
+    return dir;
+  }
+}

--- a/lib/models/book_model.dart
+++ b/lib/models/book_model.dart
@@ -5,6 +5,7 @@ class BookModel {
   final String language;
   final List<String> tags;
   final int lastPage;
+  final List<String> pages;
 
   BookModel({
     this.id,
@@ -13,6 +14,7 @@ class BookModel {
     required this.language,
     this.tags = const [],
     this.lastPage = 0,
+    this.pages = const [],
   });
 
   Map<String, dynamic> toMap() {

--- a/lib/screens/library_screen.dart
+++ b/lib/screens/library_screen.dart
@@ -1,6 +1,8 @@
 import 'package:flutter/material.dart';
 import '../database/db_helper.dart';
 import '../models/book_model.dart';
+import '../importers/importer_factory.dart';
+import 'package:file_picker/file_picker.dart';
 
 /// Displays the list of imported books.
 class LibraryScreen extends StatefulWidget {
@@ -59,6 +61,31 @@ class _LibraryScreenState extends State<LibraryScreen> {
           );
         },
       ),
+      floatingActionButton: FloatingActionButton(
+        onPressed: _pickAndImport,
+        child: const Icon(Icons.add),
+      ),
     );
+  }
+
+  Future<void> _pickAndImport() async {
+    final result = await FilePicker.platform.pickFiles();
+    if (result == null || result.files.isEmpty) return;
+    final path = result.files.single.path;
+    if (path == null) return;
+    try {
+      final importer = ImporterFactory.fromPath(path);
+      final book = await importer.import(path);
+      await DbHelper.instance.insertBook(book);
+      setState(() {
+        _books = DbHelper.instance.fetchBooks();
+      });
+    } catch (e) {
+      if (context.mounted) {
+        ScaffoldMessenger.of(context).showSnackBar(
+          SnackBar(content: Text('Import failed: $e')),
+        );
+      }
+    }
   }
 }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -12,6 +12,10 @@ dependencies:
 
   sqflite: ^2.3.2
   path_provider: ^2.1.1
+  archive: ^3.4.0
+  file_picker: ^6.1.1
+  rar: ^2.0.0
+  path: ^1.8.3
 
 
 dev_dependencies:


### PR DESCRIPTION
## Summary
- create new `lib/importers` directory with archive importers for zip/rar/7z
- extend `BookModel` to track extracted page paths
- add `ImporterFactory` and import button on library screen
- update dependencies for archive handling and file picker

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6887e90100f083269e8ccf813bba1175