### PR TITLE
Add metadata providers and import integration

### DIFF
--- a/lib/import/importer.dart
+++ b/lib/import/importer.dart
@@ -1,0 +1,17 @@
+import '../database/db_helper.dart';
+import '../metadata/metadata_service.dart';
+
+/// High level helper that imports a book path and resolves metadata.
+class Importer {
+  Importer({DbHelper? dbHelper, MetadataService? metadata})
+      : _dbHelper = dbHelper ?? DbHelper.instance,
+        _metadata = metadata ?? MetadataService();
+
+  final DbHelper _dbHelper;
+  final MetadataService _metadata;
+
+  Future<int> importPath(String path) {
+    return _dbHelper.importBook(path, _metadata);
+  }
+}
+

--- a/lib/metadata/anilist_provider.dart
+++ b/lib/metadata/anilist_provider.dart
@@ -1,0 +1,53 @@
+import 'dart:convert';
+import 'package:http/http.dart' as http;
+
+import 'metadata_provider.dart';
+
+/// Queries the AniList GraphQL API for manga metadata.
+class AniListProvider implements MetadataProvider {
+  @override
+  String get name => 'AniList';
+
+  @override
+  Future<Metadata?> search(String query) async {
+    const url = 'https://graphql.anilist.co';
+    const graphQuery = r'''
+      query(\$search: String) {
+        Media(search: \$search, type: MANGA) {
+          title {
+            romaji
+            english
+          }
+          countryOfOrigin
+          tags { name }
+        }
+      }
+    ''';
+
+    final body = jsonEncode({'query': graphQuery, 'variables': {'search': query}});
+
+    try {
+      final res = await http.post(Uri.parse(url),
+          headers: {'Content-Type': 'application/json'}, body: body);
+      if (res.statusCode != 200) return null;
+
+      final data = jsonDecode(res.body) as Map<String, dynamic>;
+      final media = data['data']?['Media'];
+      if (media == null) return null;
+
+      final title = (media['title']['english'] as String?) ??
+          (media['title']['romaji'] as String?) ??
+          query;
+      final lang = (media['countryOfOrigin'] as String?) ?? 'unknown';
+      final tags = (media['tags'] as List?)
+              ?.map((e) => e['name'] as String)
+              .toList() ??
+          <String>[];
+
+      return Metadata(title: title, language: lang, tags: tags);
+    } catch (_) {
+      return null;
+    }
+  }
+}
+

--- a/lib/metadata/doujindb_provider.dart
+++ b/lib/metadata/doujindb_provider.dart
@@ -1,0 +1,34 @@
+import 'dart:convert';
+import 'package:http/http.dart' as http;
+
+import 'metadata_provider.dart';
+
+/// Queries the DoujinDB REST API for doujin metadata.
+class DoujinDbProvider implements MetadataProvider {
+  @override
+  String get name => 'DoujinDB';
+
+  @override
+  Future<Metadata?> search(String query) async {
+    final url = Uri.parse('https://doujindb.truesight.xyz/api/search?q=$query');
+
+    try {
+      final res = await http.get(url);
+      if (res.statusCode != 200) return null;
+
+      final data = jsonDecode(res.body) as Map<String, dynamic>;
+      final results = data['results'] as List?;
+      if (results == null || results.isEmpty) return null;
+      final first = results.first as Map<String, dynamic>;
+
+      final title = first['title'] as String? ?? query;
+      final lang = first['language'] as String? ?? 'unknown';
+      final tags = (first['tags'] as List?)?.cast<String>() ?? <String>[];
+
+      return Metadata(title: title, language: lang, tags: tags);
+    } catch (_) {
+      return null;
+    }
+  }
+}
+

--- a/lib/metadata/metadata_provider.dart
+++ b/lib/metadata/metadata_provider.dart
@@ -1,0 +1,16 @@
+import 'dart:async';
+
+class Metadata {
+  final String title;
+  final String language;
+  final List<String> tags;
+
+  Metadata({required this.title, required this.language, this.tags = const []});
+}
+
+abstract class MetadataProvider {
+  String get name;
+
+  /// Return metadata for the given search query or null if not found.
+  Future<Metadata?> search(String query);
+}

--- a/lib/metadata/metadata_service.dart
+++ b/lib/metadata/metadata_service.dart
@@ -1,0 +1,23 @@
+import 'metadata_provider.dart';
+import 'anilist_provider.dart';
+import 'doujindb_provider.dart';
+
+/// Attempts to resolve metadata using all available providers.
+class MetadataService {
+  MetadataService()
+      : _providers = [AniListProvider(), DoujinDbProvider()];
+
+  final List<MetadataProvider> _providers;
+
+  /// Queries each provider in order until one returns metadata.
+  Future<Metadata?> resolve(String query) async {
+    for (final provider in _providers) {
+      final result = await provider.search(query);
+      if (result != null) {
+        return result;
+      }
+    }
+    return null;
+  }
+}
+

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -12,6 +12,7 @@ dependencies:
 
   sqflite: ^2.3.2
   path_provider: ^2.1.1
+  http: ^0.13.6
 
 
 dev_dependencies:


### PR DESCRIPTION
## Summary
- add MetadataProvider abstraction
- implement AniList and DoujinDB providers
- create MetadataService and Importer helpers
- call metadata providers from DbHelper when importing
- pull in `http` package

## Testing
- `apt-get install -y dart` *(fails: Unable to locate package dart)*
- `dart pub get` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6887e901f66c8326939040bd2a6b0d60