### PR TITLE
Add tests and CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,16 @@
+name: CI
+
+on:
+  pull_request:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: subosito/flutter-action@v2
+        with:
+          channel: stable
+      - run: flutter pub get
+      - run: flutter analyze
+      - run: flutter test

--- a/README.md
+++ b/README.md
@@ -10,3 +10,14 @@ To run the app:
 ```bash
 flutter run
 ```
+
+## Running Tests
+
+To run the analyzer and test suite locally:
+
+```bash
+flutter analyze
+flutter test
+```
+
+Make sure you have the Flutter SDK installed and dependencies fetched with `flutter pub get`.

--- a/lib/screens/library_screen.dart
+++ b/lib/screens/library_screen.dart
@@ -4,7 +4,9 @@ import '../models/book_model.dart';
 
 /// Displays the list of imported books.
 class LibraryScreen extends StatefulWidget {
-  const LibraryScreen({super.key});
+  final Future<List<BookModel>> Function()? fetchBooks;
+
+  const LibraryScreen({super.key, this.fetchBooks});
 
   @override
   State<LibraryScreen> createState() => _LibraryScreenState();
@@ -16,7 +18,7 @@ class _LibraryScreenState extends State<LibraryScreen> {
   @override
   void initState() {
     super.initState();
-    _books = DbHelper.instance.fetchBooks();
+    _books = (widget.fetchBooks ?? DbHelper().fetchBooks)();
   }
 
   @override

--- a/lib/screens/reader_screen.dart
+++ b/lib/screens/reader_screen.dart
@@ -1,0 +1,20 @@
+import 'package:flutter/material.dart';
+
+import '../models/book_model.dart';
+
+/// A very minimal reader screen that simply displays the selected book.
+class ReaderScreen extends StatelessWidget {
+  final BookModel book;
+
+  const ReaderScreen({super.key, required this.book});
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(title: Text(book.title)),
+      body: Center(
+        child: Text('Reader for ${book.title}'),
+      ),
+    );
+  }
+}

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -12,12 +12,15 @@ dependencies:
 
   sqflite: ^2.3.2
   path_provider: ^2.1.1
+  path: ^1.9.0
 
 
 dev_dependencies:
   flutter_test:
     sdk: flutter
   flutter_lints: ^2.0.0
+  sqflite_common_ffi: ^2.3.6
+  path_provider_platform_interface: any
 
 flutter:
   uses-material-design: true

--- a/test/db_helper_test.dart
+++ b/test/db_helper_test.dart
@@ -1,0 +1,55 @@
+import 'dart:io';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:path_provider_platform_interface/path_provider_platform_interface.dart';
+import 'package:sqflite_common_ffi/sqflite_ffi.dart';
+
+import 'package:mana_reader/database/db_helper.dart';
+import 'package:mana_reader/models/book_model.dart';
+
+class _FakePathProviderPlatform extends PathProviderPlatform {
+  final Directory tempDir =
+      Directory.systemTemp.createTempSync('mana_reader_test');
+
+  @override
+  Future<String?> getApplicationDocumentsPath() async {
+    return tempDir.path;
+  }
+}
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+  sqfliteFfiInit();
+  databaseFactory = databaseFactoryFfi;
+  PathProviderPlatform.instance = _FakePathProviderPlatform();
+
+  group('DbHelper', () {
+    late DbHelper dbHelper;
+
+    setUp(() {
+      PathProviderPlatform.instance = _FakePathProviderPlatform();
+      dbHelper = DbHelper();
+    });
+
+    test('insert and fetch book', () async {
+      final book =
+          BookModel(title: 'Test', path: '/tmp/test.cbz', language: 'en');
+      final id = await dbHelper.insertBook(book);
+      expect(id, isNonZero);
+
+      final books = await dbHelper.fetchBooks();
+      expect(books, hasLength(1));
+      expect(books.first.title, equals('Test'));
+    });
+
+    test('update progress', () async {
+      final book =
+          BookModel(title: 'Test', path: '/tmp/test.cbz', language: 'en');
+      final id = await dbHelper.insertBook(book);
+      await dbHelper.updateProgress(id, 5);
+      final books = await dbHelper.fetchBooks();
+      final updated = books.singleWhere((b) => b.id == id);
+      expect(updated.lastPage, equals(5));
+    });
+  });
+}

--- a/test/library_screen_test.dart
+++ b/test/library_screen_test.dart
@@ -1,0 +1,47 @@
+import 'dart:io';
+
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:path_provider_platform_interface/path_provider_platform_interface.dart';
+import 'package:mana_reader/models/book_model.dart';
+import 'package:mana_reader/screens/library_screen.dart';
+
+class _FakePathProviderPlatform extends PathProviderPlatform {
+  final Directory tempDir =
+      Directory.systemTemp.createTempSync('mana_reader_test');
+
+  @override
+  Future<String?> getApplicationDocumentsPath() async {
+    return tempDir.path;
+  }
+}
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+  setUp(() {
+    // No-op setup for path provider to avoid method channel errors.
+    PathProviderPlatform.instance = _FakePathProviderPlatform();
+  });
+
+  testWidgets('shows empty message with no books', (tester) async {
+    await tester.pumpWidget(MaterialApp(
+      home: LibraryScreen(fetchBooks: () async => []),
+    ));
+    await tester.pump();
+    await tester.pump(const Duration(seconds: 1));
+    await tester.pump(const Duration(seconds: 1));
+    expect(find.text('No books imported'), findsOneWidget);
+  });
+
+  testWidgets('displays inserted books', (tester) async {
+    final books = [BookModel(title: 'A', path: '/tmp/a.cbz', language: 'en')];
+    await tester.pumpWidget(MaterialApp(
+      home: LibraryScreen(fetchBooks: () async => books),
+    ));
+    await tester.pump();
+    await tester.pump(const Duration(seconds: 1));
+    await tester.pump(const Duration(seconds: 1));
+
+    expect(find.text('A'), findsOneWidget);
+  });
+}

--- a/test/reader_screen_test.dart
+++ b/test/reader_screen_test.dart
@@ -1,0 +1,13 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:mana_reader/models/book_model.dart';
+import 'package:mana_reader/screens/reader_screen.dart';
+
+void main() {
+  testWidgets('displays book title', (tester) async {
+    final book = BookModel(title: 'Read Me', path: '/tmp', language: 'en');
+    await tester.pumpWidget(MaterialApp(home: ReaderScreen(book: book)));
+    expect(find.text('Reader for Read Me'), findsOneWidget);
+  });
+}


### PR DESCRIPTION
## Summary
- create minimal ReaderScreen
- make LibraryScreen's database fetch injectable
- add unit and widget tests
- document how to run tests
- add CI workflow to run flutter analyze and flutter test

## Testing
- `flutter analyze`
- `flutter test`

------
https://chatgpt.com/codex/tasks/task_e_6887e90a62888326a4cd953a9dac279b