### PR TITLE
Extend database utilities and update UI fetch logic

### DIFF
--- a/lib/database/db_helper.dart
+++ b/lib/database/db_helper.dart
@@ -56,6 +56,24 @@ class DbHelper {
     return db.insert('books', book.toMap());
   }
 
+  Future<BookModel?> fetchBook(int id) async {
+    final db = await database;
+    final maps = await db.query('books', where: 'id = ?', whereArgs: [id]);
+    if (maps.isEmpty) return null;
+    return BookModel.fromMap(maps.first);
+  }
+
+  Future<int> updateBook(BookModel book) async {
+    if (book.id == null) throw ArgumentError('Book id cannot be null');
+    final db = await database;
+    return db.update('books', book.toMap(), where: 'id = ?', whereArgs: [book.id]);
+  }
+
+  Future<int> deleteBook(int id) async {
+    final db = await database;
+    return db.delete('books', where: 'id = ?', whereArgs: [id]);
+  }
+
 
   /// Imports a book from the given path and resolves metadata using [service].
   Future<int> importBook(String path, MetadataService service) async {
@@ -71,15 +89,18 @@ class DbHelper {
     return insertBook(book);
   }
 
-  Future<List<BookModel>> fetchBooks() async {
-
+  Future<List<BookModel>> fetchBooks({
+    List<String>? tags,
+    String? author,
+    bool? unread,
+  }) async {
     final db = await database;
     final where = <String>[];
     final args = <dynamic>[];
     if (tags != null && tags.isNotEmpty) {
       for (final tag in tags) {
         where.add('tags LIKE ?');
-        args.add('%' + tag + '%');
+        args.add('%$tag%');
       }
     }
     if (author != null && author.isNotEmpty) {

--- a/lib/screens/library_screen.dart
+++ b/lib/screens/library_screen.dart
@@ -8,7 +8,11 @@ import 'package:file_picker/file_picker.dart';
 
 /// Displays the list of imported books.
 class LibraryScreen extends StatefulWidget {
-  final Future<List<BookModel>> Function()? fetchBooks;
+  final Future<List<BookModel>> Function({
+    List<String>? tags,
+    String? author,
+    bool? unread,
+  })? fetchBooks;
 
   const LibraryScreen({super.key, this.fetchBooks});
 
@@ -35,7 +39,8 @@ class _LibraryScreenState extends State<LibraryScreen> {
 
   void _loadBooks() {
     setState(() {
-      _books = DbHelper.instance.fetchBooks(
+      final fetch = widget.fetchBooks ?? DbHelper.instance.fetchBooks;
+      _books = fetch(
         tags: _selectedTag != null ? [_selectedTag!] : null,
         author: _selectedAuthor,
         unread: _showUnread ? true : null,
@@ -207,9 +212,7 @@ class _LibraryScreenState extends State<LibraryScreen> {
       final importer = ImporterFactory.fromPath(path);
       final book = await importer.import(path);
       await DbHelper.instance.insertBook(book);
-      setState(() {
-        _books = DbHelper.instance.fetchBooks();
-      });
+      _loadBooks();
     } catch (e) {
       if (context.mounted) {
         ScaffoldMessenger.of(context).showSnackBar(

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -16,6 +16,9 @@ dependencies:
   path: ^1.9.0
 
   http: ^0.13.6
+  file_picker: ^6.1.1
+  archive: ^3.3.7
+  rar: ^3.0.1
 
 
 

--- a/test/db_helper_test.dart
+++ b/test/db_helper_test.dart
@@ -52,5 +52,42 @@ void main() {
       expect(updated.lastPage, equals(5));
     });
 
+    test('fetch by id', () async {
+      final book =
+          BookModel(title: 'ById', path: '/tmp/test.cbz', language: 'en');
+      final id = await dbHelper.insertBook(book);
+      final fetched = await dbHelper.fetchBook(id);
+      expect(fetched, isNotNull);
+      expect(fetched!.id, equals(id));
+      expect(fetched.title, equals('ById'));
+    });
+
+    test('update book metadata', () async {
+      final id = await dbHelper.insertBook(
+          BookModel(title: 'Old', path: '/tmp/test.cbz', language: 'en'));
+      final updated = BookModel(
+        id: id,
+        title: 'New',
+        path: '/tmp/test.cbz',
+        language: 'jp',
+        author: 'Me',
+        tags: ['tag'],
+      );
+      await dbHelper.updateBook(updated);
+      final fetched = await dbHelper.fetchBook(id);
+      expect(fetched!.title, equals('New'));
+      expect(fetched.language, equals('jp'));
+      expect(fetched.author, equals('Me'));
+      expect(fetched.tags, equals(['tag']));
+    });
+
+    test('delete book', () async {
+      final id = await dbHelper
+          .insertBook(BookModel(title: 'Del', path: '/tmp/a.cbz', language: 'en'));
+      await dbHelper.deleteBook(id);
+      final books = await dbHelper.fetchBooks();
+      expect(books, isEmpty);
+    });
+
   });
 }

--- a/test/library_screen_test.dart
+++ b/test/library_screen_test.dart
@@ -25,7 +25,9 @@ void main() {
 
   testWidgets('shows empty message with no books', (tester) async {
     await tester.pumpWidget(MaterialApp(
-      home: LibraryScreen(fetchBooks: () async => []),
+      home: LibraryScreen(
+        fetchBooks: ({tags, author, unread}) async => [],
+      ),
     ));
     await tester.pump();
     await tester.pump(const Duration(seconds: 1));
@@ -36,7 +38,9 @@ void main() {
   testWidgets('displays inserted books', (tester) async {
     final books = [BookModel(title: 'A', path: '/tmp/a.cbz', language: 'en')];
     await tester.pumpWidget(MaterialApp(
-      home: LibraryScreen(fetchBooks: () async => books),
+      home: LibraryScreen(
+        fetchBooks: ({tags, author, unread}) async => books,
+      ),
     ));
     await tester.pump();
     await tester.pump(const Duration(seconds: 1));


### PR DESCRIPTION
## Summary
- add `file_picker`, `archive` and `rar` dependencies
- expand `DbHelper` with fetch by id, update and delete
- expose filter parameters in `fetchBooks`
- refresh book list via injected callback in `LibraryScreen`
- cover new behaviours in database and screen tests

## Testing
- `flutter analyze` *(fails: command not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6887f5b2d3e4832685f5f92ed3ae09b2