### PR TITLE
Add PDF and folder importers with metadata support

### DIFF
--- a/lib/import/importer.dart
+++ b/lib/import/importer.dart
@@ -1,4 +1,6 @@
 import '../database/db_helper.dart';
+import '../importers/importer_factory.dart';
+import '../models/book_model.dart';
 import '../metadata/metadata_service.dart';
 
 /// High level helper that imports a book path and resolves metadata.
@@ -10,8 +12,21 @@ class Importer {
   final DbHelper _dbHelper;
   final MetadataService _metadata;
 
-  Future<int> importPath(String path) {
-    return _dbHelper.importBook(path, _metadata);
+  Future<int> importPath(String path) async {
+    final inner = ImporterFactory.fromPath(path);
+    final book = await inner.import(path);
+
+    final meta = await _metadata.resolve(book.title);
+    final merged = BookModel(
+      title: meta?.title ?? book.title,
+      path: book.path,
+      author: meta?.author ?? book.author,
+      language: meta?.language ?? book.language,
+      tags: meta?.tags ?? book.tags,
+      pages: book.pages,
+    );
+
+    return _dbHelper.insertBook(merged);
   }
 }
 

--- a/lib/importers/folder_importer.dart
+++ b/lib/importers/folder_importer.dart
@@ -1,0 +1,37 @@
+import 'dart:io';
+
+import 'package:path/path.dart' as p;
+
+import '../models/book_model.dart';
+import 'importer.dart';
+
+class FolderImporter extends Importer {
+  @override
+  Future<BookModel> import(String path) async {
+    final dir = Directory(path);
+    if (!await dir.exists()) {
+      throw Exception('Directory not found');
+    }
+    final pages = dir
+        .listSync()
+        .whereType<File>()
+        .where((f) => _isImage(f.path))
+        .map((f) => f.path)
+        .toList()
+      ..sort();
+    return BookModel(
+      title: p.basename(path),
+      path: dir.path,
+      language: 'unknown',
+      pages: pages,
+    );
+  }
+
+  bool _isImage(String path) {
+    final lower = path.toLowerCase();
+    return lower.endsWith('.jpg') ||
+        lower.endsWith('.jpeg') ||
+        lower.endsWith('.png') ||
+        lower.endsWith('.gif');
+  }
+}

--- a/lib/importers/importer_factory.dart
+++ b/lib/importers/importer_factory.dart
@@ -1,7 +1,11 @@
+import 'dart:io';
+
 import 'importer.dart';
 import 'zip_importer.dart';
 import 'rar_importer.dart';
 import 'seven_zip_importer.dart';
+import 'pdf_importer.dart';
+import 'folder_importer.dart';
 
 class ImporterFactory {
   static Importer fromPath(String path) {
@@ -12,6 +16,10 @@ class ImporterFactory {
       return RarImporter();
     } else if (lower.endsWith('.cb7') || lower.endsWith('.7z')) {
       return SevenZipImporter();
+    } else if (lower.endsWith('.pdf')) {
+      return PdfImporter();
+    } else if (FileSystemEntity.isDirectorySync(path)) {
+      return FolderImporter();
     } else {
       throw UnsupportedError('Unsupported archive type');
     }

--- a/lib/importers/pdf_importer.dart
+++ b/lib/importers/pdf_importer.dart
@@ -1,0 +1,46 @@
+import 'dart:io';
+import 'dart:ui' as ui;
+
+import 'package:pdf_render/pdf_render.dart';
+import 'package:path/path.dart' as p;
+import 'package:path_provider/path_provider.dart';
+
+import '../models/book_model.dart';
+import 'importer.dart';
+
+class PdfImporter extends Importer {
+  @override
+  Future<BookModel> import(String filePath) async {
+    final doc = await PdfDocument.openFile(filePath);
+    final baseName = p.basenameWithoutExtension(filePath);
+    final destDir = await _createDestDir(baseName);
+    final pages = <String>[];
+    for (var i = 1; i <= doc.pageCount; i++) {
+      final page = await doc.getPage(i);
+      final img = await page.render(
+          width: page.width.toInt(), height: page.height.toInt());
+      final ui.Image image = await img.createImageIfNotAvailable();
+      final bytes =
+          (await image.toByteData(format: ui.ImageByteFormat.png))!.buffer.asUint8List();
+      final imagePath = p.join(destDir.path, '${i.toString().padLeft(4, '0')}.png');
+      final file = File(imagePath);
+      await file.writeAsBytes(bytes);
+      await page.close();
+      pages.add(imagePath);
+    }
+    await doc.close();
+    return BookModel(
+      title: baseName,
+      path: destDir.path,
+      language: 'unknown',
+      pages: pages,
+    );
+  }
+
+  Future<Directory> _createDestDir(String baseName) async {
+    final docs = await getApplicationDocumentsDirectory();
+    final dir = Directory(p.join(docs.path, 'books', baseName));
+    await dir.create(recursive: true);
+    return dir;
+  }
+}

--- a/lib/screens/library_screen.dart
+++ b/lib/screens/library_screen.dart
@@ -2,7 +2,7 @@ import 'package:flutter/material.dart';
 import '../database/db_helper.dart';
 import '../models/book_model.dart';
 
-import '../importers/importer_factory.dart';
+import '../import/importer.dart';
 import 'package:file_picker/file_picker.dart';
 
 
@@ -209,9 +209,8 @@ class _LibraryScreenState extends State<LibraryScreen> {
     final path = result.files.single.path;
     if (path == null) return;
     try {
-      final importer = ImporterFactory.fromPath(path);
-      final book = await importer.import(path);
-      await DbHelper.instance.insertBook(book);
+      final importer = Importer();
+      await importer.importPath(path);
       _loadBooks();
     } catch (e) {
       if (context.mounted) {

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -19,6 +19,7 @@ dependencies:
   file_picker: ^6.1.1
   archive: ^3.3.7
   rar: ^3.0.1
+  pdf_render: ^1.4.0
 
 
 


### PR DESCRIPTION
## Summary
- add `PdfImporter` for converting PDFs to image pages
- allow importing plain folders of images
- extend `ImporterFactory` to handle PDF and folder paths
- resolve metadata when importing and insert into DB
- use the new high-level `Importer` in LibraryScreen
- add `pdf_render` dependency

## Testing
- `flutter test -q` *(fails: command not found)*
- `dart --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6888004fdd60832685fce93059d1d89b