### PR TITLE
Add tests and extend CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,13 +4,14 @@ on:
   pull_request:
 
 jobs:
-  build:
+  test:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
       - uses: subosito/flutter-action@v2
         with:
           channel: stable
+          cache: true
       - run: flutter pub get
       - run: flutter analyze
       - run: flutter test

--- a/README.md
+++ b/README.md
@@ -48,3 +48,9 @@ flutter test
 
 Make sure you have the Flutter SDK installed and dependencies fetched with `flutter pub get`.
 
+## Continuous Integration
+
+Every pull request runs the workflow in `.github/workflows/ci.yml` which sets up
+Flutter, runs `flutter analyze` and executes the test suite. This helps ensure
+that all contributed code is properly formatted and tested before merging.
+

--- a/test/importer_test.dart
+++ b/test/importer_test.dart
@@ -1,0 +1,60 @@
+import 'dart:convert';
+import 'dart:io';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:path/path.dart' as p;
+import 'package:path_provider_platform_interface/path_provider_platform_interface.dart';
+import 'package:archive/archive.dart';
+
+import 'package:mana_reader/importers/importer_factory.dart';
+import 'package:mana_reader/importers/folder_importer.dart';
+import 'package:mana_reader/importers/zip_importer.dart';
+
+
+class _FakePathProviderPlatform extends PathProviderPlatform {
+  final Directory tempDir = Directory.systemTemp.createTempSync('mana_reader_test');
+
+  @override
+  Future<String?> getApplicationDocumentsPath() async => tempDir.path;
+}
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+  PathProviderPlatform.instance = _FakePathProviderPlatform();
+
+  group('ImporterFactory', () {
+    test('selects importer based on extension', () {
+      expect(ImporterFactory.fromPath('a.cbz'), isA<ZipImporter>());
+      expect(ImporterFactory.fromPath('dir'), isA<FolderImporter>());
+    });
+  });
+
+  group('Importers', () {
+    test('FolderImporter reads images', () async {
+      final dir = Directory.systemTemp.createTempSync();
+      final img = base64Decode('iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8Xw8AAiMB7g6lbYkAAAAASUVORK5CYII=');
+      final imgPath = p.join(dir.path, 'a.png');
+      File(imgPath).writeAsBytesSync(img);
+
+      final importer = FolderImporter();
+      final book = await importer.import(dir.path);
+      expect(book.title, p.basename(dir.path));
+      expect(book.pages, [imgPath]);
+    });
+
+    test('ZipImporter extracts images', () async {
+      final tmp = Directory.systemTemp.createTempSync();
+      final img = base64Decode('iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8Xw8AAiMB7g6lbYkAAAAASUVORK5CYII=');
+      final archive = Archive()
+        ..addFile(ArchiveFile('b.png', img.length, img));
+      final bytes = ZipEncoder().encode(archive)!;
+      final zipPath = p.join(tmp.path, 'b.cbz');
+      File(zipPath).writeAsBytesSync(bytes);
+
+      final importer = ZipImporter();
+      final book = await importer.import(zipPath);
+      expect(book.pages.length, 1);
+      expect(File(book.pages.first).existsSync(), isTrue);
+    });
+  });
+}

--- a/test/library_screen_test.dart
+++ b/test/library_screen_test.dart
@@ -48,4 +48,18 @@ void main() {
 
     expect(find.text('A'), findsOneWidget);
   });
+
+  testWidgets('toggles list and grid view', (tester) async {
+    final books = [BookModel(title: 'B', path: '/tmp/b.cbz', language: 'en')];
+    await tester.pumpWidget(MaterialApp(
+      home: LibraryScreen(fetchBooks: ({tags, author, unread}) async => books),
+    ));
+    await tester.pumpAndSettle();
+
+    expect(find.byType(GridView), findsOneWidget);
+    final btn = find.byIcon(Icons.view_list);
+    await tester.tap(btn);
+    await tester.pumpAndSettle();
+    expect(find.byType(ListView), findsOneWidget);
+  });
 }

--- a/test/reader_screen_test.dart
+++ b/test/reader_screen_test.dart
@@ -27,4 +27,32 @@ void main() {
     expect(find.text('Read Me'), findsOneWidget);
     expect(find.byType(PageView), findsOneWidget);
   });
+
+  testWidgets('toggles reading direction', (tester) async {
+    final dir = Directory.systemTemp.createTempSync();
+    final imgPath = p.join(dir.path, 'a.png');
+    File(imgPath).writeAsBytesSync(base64Decode('iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8Xw8AAiMB7g6lbYkAAAAASUVORK5CYII='));
+    final book = BookModel(title: 'Read', path: dir.path, language: 'en', pages: [imgPath]);
+    await tester.pumpWidget(MaterialApp(home: ReaderScreen(book: book)));
+    final btn = find.byIcon(Icons.format_textdirection_l_to_r);
+    expect(btn, findsOneWidget);
+    await tester.tap(btn);
+    await tester.pump();
+    expect(find.byIcon(Icons.format_textdirection_r_to_l), findsOneWidget);
+  });
+
+  testWidgets('toggles double page mode', (tester) async {
+    final dir = Directory.systemTemp.createTempSync();
+    final imgPath = p.join(dir.path, 'a.png');
+    final img2 = p.join(dir.path, 'b.png');
+    File(imgPath).writeAsBytesSync(base64Decode('iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8Xw8AAiMB7g6lbYkAAAAASUVORK5CYII='));
+    File(img2).writeAsBytesSync(base64Decode('iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8Xw8AAiMB7g6lbYkAAAAASUVORK5CYII='));
+    final book = BookModel(title: 'Read', path: dir.path, language: 'en', pages: [imgPath, img2]);
+    await tester.pumpWidget(MaterialApp(home: ReaderScreen(book: book)));
+    final btn = find.byIcon(Icons.filter_2);
+    expect(btn, findsOneWidget);
+    await tester.tap(btn);
+    await tester.pump();
+    expect(find.byIcon(Icons.filter_1), findsOneWidget);
+  });
 }


### PR DESCRIPTION
## Summary
- add tests for DbHelper filters, metadata import, and history
- test importer factory and importers
- expand widget tests for ReaderScreen and LibraryScreen
- cache Flutter in CI and rename job
- document running tests and CI in README

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68880fcdf3488326a9444dd162a31c67