### PR TITLE
Ignore platform icons

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -43,3 +43,11 @@ app.*.map.json
 /android/app/debug
 /android/app/profile
 /android/app/release
+
+# Platform icons
+android/app/src/main/res/mipmap-*
+ios/Runner/Assets.xcassets/AppIcon.appiconset/*
+ios/Runner/Assets.xcassets/LaunchImage.imageset/*
+macos/Runner/Assets.xcassets/*.png
+windows/runner/resources/app_icon.ico
+

--- a/README.md
+++ b/README.md
@@ -21,6 +21,10 @@ From the repository root run `flutter run` and select the desired target device.
 - **iOS / macOS**: project folders are included but contain only placeholders. Platform support will be added later.
 - **Linux / Windows**: similarly include placeholder folders for future desktop support.
 
+## Platform Icons
+
+Platform icon files are not stored in this repository. Run `flutter create .` or use your own script to generate the default icons before building for a platform.
+
 ## Roadmap
 
 Upcoming features include:


### PR DESCRIPTION
## Summary
- ignore platform icon assets
- document generating icons locally in README

## Testing
- `flutter --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6888241f25348326b7187f1227d6c0cb