### PR TITLE
Add ignore rules for platform icons

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -45,6 +45,8 @@ app.*.map.json
 /android/app/release
 
 # Platform icons
+**/Assets.xcassets/*.png
+**/resources/*.ico
 android/app/src/main/res/mipmap-*
 ios/Runner/Assets.xcassets/AppIcon.appiconset/*
 ios/Runner/Assets.xcassets/LaunchImage.imageset/*

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ From the repository root run `flutter run` and select the desired target device.
 
 ## Platform Icons
 
-Platform icon files are not stored in this repository. Run `flutter create .` or use your own script to generate the default icons before building for a platform.
+Platform icon files are not stored in this repository. Generate them locally with `flutter create .` or copy your own icons into the platform asset folders before building.
 
 ## Roadmap
 

--- a/android/.gitignore
+++ b/android/.gitignore
@@ -12,3 +12,6 @@ GeneratedPluginRegistrant.java
 key.properties
 **/*.keystore
 **/*.jks
+
+# Icon assets
+**/res/**/*.png

--- a/ios/.gitignore
+++ b/ios/.gitignore
@@ -1,0 +1,3 @@
+# Icon assets
+**/Assets.xcassets/*.png
+

--- a/macos/.gitignore
+++ b/macos/.gitignore
@@ -1,0 +1,3 @@
+# Icon assets
+**/Assets.xcassets/*.png
+

--- a/windows/.gitignore
+++ b/windows/.gitignore
@@ -1,0 +1,3 @@
+# Icon assets
+**/resources/*.ico
+


### PR DESCRIPTION
## Summary
- add wildcard icon patterns to `.gitignore`
- ignore icon assets per platform
- clarify README note about generating icons locally

## Testing
- `flutter analyze` *(fails: command not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68882cd3e9a48326a75c745bf4e60e90