### PR TITLE
Ignore generated icon assets

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -51,3 +51,7 @@ ios/Runner/Assets.xcassets/LaunchImage.imageset/*
 macos/Runner/Assets.xcassets/*.png
 windows/runner/resources/app_icon.ico
 
+android/app/src/main/res/mipmap*/ic_launcher.png
+ios/Runner/Assets.xcassets/**
+macos/Runner/Assets.xcassets/**
+windows/runner/resources/*.ico

--- a/android/.gitignore
+++ b/android/.gitignore
@@ -12,3 +12,7 @@ GeneratedPluginRegistrant.java
 key.properties
 **/*.keystore
 **/*.jks
+android/app/src/main/res/mipmap*/ic_launcher.png
+ios/Runner/Assets.xcassets/**
+macos/Runner/Assets.xcassets/**
+windows/runner/resources/*.ico


### PR DESCRIPTION
## Summary
- add ignore rules for icon assets in platform folders

## Testing
- `flutter --version` *(fails: command not found)*
- `apt-get install -y flutter` *(fails: Unable to locate package)*

------
https://chatgpt.com/codex/tasks/task_e_68882cf9056c83268254bc6c5815f30c