### PR TITLE
Fix mounted check in _initFilters

### DIFF
--- a/lib/screens/library_screen.dart
+++ b/lib/screens/library_screen.dart
@@ -53,6 +53,7 @@ class _LibraryScreenState extends State<LibraryScreen> {
   Future<void> _initFilters() async {
     final tags = await DbHelper.instance.fetchAllTags();
     final authors = await DbHelper.instance.fetchAllAuthors();
+    if (!mounted) return;
     setState(() {
       _tags = tags;
       _authors = authors;


### PR DESCRIPTION
## Summary
- avoid calling setState when disposed in `LibraryScreen._initFilters`

## Testing
- `apt-get update`
- *(tests could not be run: flutter/dart not installed)*

------
https://chatgpt.com/codex/tasks/task_e_6889064be4d88326983f85423f57578e