### PR TITLE
Add bookmark feature and slider

### DIFF
--- a/test/db_helper_test.dart
+++ b/test/db_helper_test.dart
@@ -146,5 +146,16 @@ void main() {
       expect(history.first['page'], 3);
     });
 
+    test('bookmark add and remove', () async {
+      final id = await dbHelper
+          .insertBook(BookModel(title: 'Bm', path: '/tmp/h.cbz', language: 'en'));
+      await dbHelper.addBookmark(id, 2);
+      var bookmarks = await dbHelper.fetchBookmarks(id);
+      expect(bookmarks, contains(2));
+      await dbHelper.removeBookmark(id, 2);
+      bookmarks = await dbHelper.fetchBookmarks(id);
+      expect(bookmarks, isEmpty);
+    });
+
   });
 }

--- a/test/reader_screen_test.dart
+++ b/test/reader_screen_test.dart
@@ -55,4 +55,15 @@ void main() {
     await tester.pump();
     expect(find.byIcon(Icons.filter_1), findsOneWidget);
   });
+
+  testWidgets('shows bookmark toggle and slider', (tester) async {
+    final dir = Directory.systemTemp.createTempSync();
+    final imgPath = p.join(dir.path, 'a.png');
+    File(imgPath).writeAsBytesSync(base64Decode(
+        'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8Xw8AAiMB7g6lbYkAAAAASUVORK5CYII='));
+    final book = BookModel(title: 'Read', path: dir.path, language: 'en', pages: [imgPath]);
+    await tester.pumpWidget(MaterialApp(home: ReaderScreen(book: book)));
+    expect(find.byIcon(Icons.bookmark_border), findsOneWidget);
+    expect(find.byType(Slider), findsOneWidget);
+  });
 }


### PR DESCRIPTION
## Summary
- extend DbHelper with bookmarks table and methods
- support bookmarking pages and slider navigation in ReaderScreen
- test DbHelper bookmark CRUD and ReaderScreen widgets

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_688909b2ad3c83269733b180f4bd7afc