### PR TITLE
Implement book deletion via long press

### DIFF
--- a/lib/screens/library_screen.dart
+++ b/lib/screens/library_screen.dart
@@ -136,6 +136,7 @@ class _LibraryScreenState extends State<LibraryScreen> {
                       builder: (_) => ReaderScreen(book: book),
                     ),
                   ),
+                  onLongPress: () => _confirmDelete(book),
                   child: GridTile(
                     child: FutureBuilder<String?>(
                       future: _thumbnailFor(book),
@@ -187,6 +188,7 @@ class _LibraryScreenState extends State<LibraryScreen> {
                       builder: (_) => ReaderScreen(book: book),
                     ),
                   ),
+                  onLongPress: () => _confirmDelete(book),
                 );
               },
             );
@@ -262,6 +264,31 @@ class _LibraryScreenState extends State<LibraryScreen> {
         child: const Icon(Icons.add),
       ),
     );
+  }
+
+  Future<void> _confirmDelete(BookModel book) async {
+    final confirm = await showDialog<bool>(
+      context: context,
+      builder: (_) => AlertDialog(
+        title: const Text('Delete Book'),
+        content: Text('Delete "${book.title}"?'),
+        actions: [
+          TextButton(
+            onPressed: () => Navigator.pop(context, false),
+            child: const Text('Cancel'),
+          ),
+          TextButton(
+            onPressed: () => Navigator.pop(context, true),
+            child: const Text('Delete'),
+          ),
+        ],
+      ),
+    );
+
+    if (confirm == true) {
+      await DbHelper.instance.deleteBook(book.id!);
+      if (mounted) _loadBooks();
+    }
   }
 
   Future<void> _pickAndImport() async {

--- a/test/library_screen_test.dart
+++ b/test/library_screen_test.dart
@@ -62,4 +62,16 @@ void main() {
     await tester.pumpAndSettle();
     expect(find.byType(ListView), findsOneWidget);
   });
+
+  testWidgets('shows delete dialog on long press', (tester) async {
+    final books = [BookModel(id: 1, title: 'X', path: '/tmp/x.cbz', language: 'en')];
+    await tester.pumpWidget(MaterialApp(
+      home: LibraryScreen(fetchBooks: ({tags, author, unread}) async => books),
+    ));
+    await tester.pumpAndSettle();
+
+    await tester.longPress(find.text('X'));
+    await tester.pumpAndSettle();
+    expect(find.text('Delete Book'), findsOneWidget);
+  });
 }


### PR DESCRIPTION
## Summary
- enable long‑press gesture on grid and list items in `LibraryScreen`
- prompt for delete confirmation
- delete the book and refresh library on confirmation
- test delete dialog appearance

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68890f4face08326904e9ff35babf0ce