### PR TITLE
Add BookDetailScreen for editing metadata

### DIFF
--- a/lib/screens/book_detail_screen.dart
+++ b/lib/screens/book_detail_screen.dart
@@ -1,0 +1,98 @@
+import 'package:flutter/material.dart';
+
+import '../database/db_helper.dart';
+import '../models/book_model.dart';
+
+/// Displays and edits metadata for a [BookModel].
+class BookDetailScreen extends StatefulWidget {
+  final BookModel book;
+  const BookDetailScreen({super.key, required this.book});
+
+  @override
+  State<BookDetailScreen> createState() => _BookDetailScreenState();
+}
+
+class _BookDetailScreenState extends State<BookDetailScreen> {
+  late final TextEditingController _titleController;
+  late final TextEditingController _authorController;
+  late final TextEditingController _languageController;
+  late final TextEditingController _tagsController;
+
+  @override
+  void initState() {
+    super.initState();
+    final book = widget.book;
+    _titleController = TextEditingController(text: book.title);
+    _authorController = TextEditingController(text: book.author);
+    _languageController = TextEditingController(text: book.language);
+    _tagsController = TextEditingController(text: book.tags.join(', '));
+  }
+
+  @override
+  void dispose() {
+    _titleController.dispose();
+    _authorController.dispose();
+    _languageController.dispose();
+    _tagsController.dispose();
+    super.dispose();
+  }
+
+  Future<void> _save() async {
+    final updated = BookModel(
+      id: widget.book.id,
+      title: _titleController.text,
+      path: widget.book.path,
+      author: _authorController.text,
+      language: _languageController.text,
+      tags: _tagsController.text
+          .split(',')
+          .map((e) => e.trim())
+          .where((e) => e.isNotEmpty)
+          .toList(),
+      lastPage: widget.book.lastPage,
+      pages: widget.book.pages,
+    );
+    await DbHelper.instance.updateBook(updated);
+    if (mounted) Navigator.pop(context, updated);
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(
+        title: const Text('Book Details'),
+        actions: [
+          IconButton(
+            icon: const Icon(Icons.save),
+            onPressed: _save,
+          ),
+        ],
+      ),
+      body: Padding(
+        padding: const EdgeInsets.all(16),
+        child: ListView(
+          children: [
+            TextField(
+              controller: _titleController,
+              decoration: const InputDecoration(labelText: 'Title'),
+            ),
+            TextField(
+              controller: _authorController,
+              decoration: const InputDecoration(labelText: 'Author'),
+            ),
+            TextField(
+              controller: _languageController,
+              decoration: const InputDecoration(labelText: 'Language'),
+            ),
+            TextField(
+              controller: _tagsController,
+              decoration:
+                  const InputDecoration(labelText: 'Tags (comma separated)'),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}
+

--- a/lib/screens/library_screen.dart
+++ b/lib/screens/library_screen.dart
@@ -6,6 +6,7 @@ import '../models/book_model.dart';
 
 import '../import/importer.dart';
 import 'package:file_picker/file_picker.dart';
+import 'book_detail_screen.dart';
 
 
 /// Displays the list of imported books.
@@ -168,6 +169,14 @@ class _LibraryScreenState extends State<LibraryScreen> {
                         book.title,
                         textAlign: TextAlign.center,
                       ),
+                      trailing: PopupMenuButton<String>(
+                        onSelected: (value) {
+                          if (value == 'edit') _openDetails(book);
+                        },
+                        itemBuilder: (_) => const [
+                          PopupMenuItem(value: 'edit', child: Text('Edit')),
+                        ],
+                      ),
                     ),
                   ),
                 );
@@ -189,6 +198,14 @@ class _LibraryScreenState extends State<LibraryScreen> {
                     ),
                   ),
                   onLongPress: () => _confirmDelete(book),
+                  trailing: PopupMenuButton<String>(
+                    onSelected: (value) {
+                      if (value == 'edit') _openDetails(book);
+                    },
+                    itemBuilder: (_) => const [
+                      PopupMenuItem(value: 'edit', child: Text('Edit')),
+                    ],
+                  ),
                 );
               },
             );
@@ -289,6 +306,14 @@ class _LibraryScreenState extends State<LibraryScreen> {
       await DbHelper.instance.deleteBook(book.id!);
       if (mounted) _loadBooks();
     }
+  }
+
+  Future<void> _openDetails(BookModel book) async {
+    await Navigator.push(
+      context,
+      MaterialPageRoute(builder: (_) => BookDetailScreen(book: book)),
+    );
+    if (mounted) _loadBooks();
   }
 
   Future<void> _pickAndImport() async {

--- a/test/library_screen_test.dart
+++ b/test/library_screen_test.dart
@@ -74,4 +74,19 @@ void main() {
     await tester.pumpAndSettle();
     expect(find.text('Delete Book'), findsOneWidget);
   });
+
+  testWidgets('opens detail screen from menu', (tester) async {
+    final books = [BookModel(id: 1, title: 'E', path: '/tmp/e.cbz', language: 'en')];
+    await tester.pumpWidget(MaterialApp(
+      home: LibraryScreen(fetchBooks: ({tags, author, unread}) async => books),
+    ));
+    await tester.pumpAndSettle();
+
+    await tester.tap(find.byIcon(Icons.more_vert).first);
+    await tester.pumpAndSettle();
+    await tester.tap(find.text('Edit'));
+    await tester.pumpAndSettle();
+
+    expect(find.text('Book Details'), findsOneWidget);
+  });
 }


### PR DESCRIPTION
## Summary
- add `BookDetailScreen` for viewing and editing book metadata
- open the detail screen from `LibraryScreen` via context menu
- test new navigation flow

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68891191876c8326a14e06febfa9e60d