### PR TITLE
Verify presence of 7z before extraction

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ Mana Reader aims to be a lightweight, cross‑platform manga and doujinshi reade
 
 - **Dart**: >=2.17.0 <3.0.0
 - **Flutter**: tested with Flutter 3; newer versions in the same major series should work.
+- **7-Zip**: required for importing `.cb7`/`.7z` archives. Install `7z` and ensure it is available in your `PATH` (e.g. `sudo apt-get install p7zip-full`).
 
 ## Development Setup
 

--- a/lib/importers/seven_zip_importer.dart
+++ b/lib/importers/seven_zip_importer.dart
@@ -9,6 +9,7 @@ import 'importer.dart';
 class SevenZipImporter extends Importer {
   @override
   Future<BookModel> import(String filePath) async {
+    await _verifySevenZip();
     final baseName = p.basenameWithoutExtension(filePath);
     final destDir = await _createDestDir(baseName);
     final result = await Process.run('7z', ['x', filePath, '-o${destDir.path}']);
@@ -49,5 +50,18 @@ class SevenZipImporter extends Importer {
         lower.endsWith('.jpeg') ||
         lower.endsWith('.png') ||
         lower.endsWith('.gif');
+  }
+
+  Future<void> _verifySevenZip() async {
+    final cmd = Platform.isWindows ? 'where' : 'which';
+    try {
+      final result = await Process.run(cmd, ['7z']);
+      if (result.exitCode != 0) {
+        throw const ProcessException('7z', []);
+      }
+    } on ProcessException {
+      throw Exception(
+          '7-Zip executable not found. Please install 7-Zip and ensure "7z" is in your PATH.');
+    }
   }
 }


### PR DESCRIPTION
## Summary
- check that `7z` is available before using it in `SevenZipImporter`
- mention 7-Zip as a requirement in the README

## Testing
- `apt-get update`
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68891618c8d48326ad02e8a0af0f82d7