### PR TITLE
Add search and sorting

### DIFF
--- a/lib/screens/library_screen.dart
+++ b/lib/screens/library_screen.dart
@@ -8,13 +8,14 @@ import '../import/importer.dart';
 import 'package:file_picker/file_picker.dart';
 import 'book_detail_screen.dart';
 
-
 /// Displays the list of imported books.
 class LibraryScreen extends StatefulWidget {
   final Future<List<BookModel>> Function({
     List<String>? tags,
     String? author,
     bool? unread,
+    String? query,
+    String? orderBy,
   })? fetchBooks;
 
   const LibraryScreen({super.key, this.fetchBooks});
@@ -31,6 +32,8 @@ class _LibraryScreenState extends State<LibraryScreen> {
   String? _selectedAuthor;
   bool _showUnread = false;
   bool _isGrid = true;
+  String _searchQuery = '';
+  String _sortOrder = 'title';
 
   @override
   void initState() {
@@ -47,6 +50,8 @@ class _LibraryScreenState extends State<LibraryScreen> {
         tags: _selectedTag != null ? [_selectedTag!] : null,
         author: _selectedAuthor,
         unread: _showUnread ? true : null,
+        query: _searchQuery.isNotEmpty ? _searchQuery : null,
+        orderBy: _sortOrder,
       );
     });
   }
@@ -59,7 +64,6 @@ class _LibraryScreenState extends State<LibraryScreen> {
       _tags = tags;
       _authors = authors;
     });
-
   }
 
   final Map<String, Future<String?>> _thumbCache = {};
@@ -99,8 +103,33 @@ class _LibraryScreenState extends State<LibraryScreen> {
   Widget build(BuildContext context) {
     return Scaffold(
       appBar: AppBar(
-        title: const Text('Library'),
+        title: TextField(
+          decoration: const InputDecoration(
+            hintText: 'Search title',
+            border: InputBorder.none,
+          ),
+          onChanged: (v) {
+            _searchQuery = v;
+            _loadBooks();
+          },
+        ),
         actions: [
+          DropdownButtonHideUnderline(
+            child: DropdownButton<String>(
+              value: _sortOrder,
+              items: const [
+                DropdownMenuItem(value: 'title', child: Text('Title')),
+                DropdownMenuItem(value: 'author', child: Text('Author')),
+                DropdownMenuItem(value: 'recent', child: Text('Recently Read')),
+              ],
+              onChanged: (value) {
+                if (value != null) {
+                  setState(() => _sortOrder = value);
+                  _loadBooks();
+                }
+              },
+            ),
+          ),
           IconButton(
             icon: Icon(_isGrid ? Icons.view_list : Icons.grid_on),
             onPressed: () => setState(() => _isGrid = !_isGrid),

--- a/lib/screens/reader_screen.dart
+++ b/lib/screens/reader_screen.dart
@@ -155,7 +155,8 @@ class _ReaderScreenState extends State<ReaderScreen> {
     if (id == null) return;
 
     final db = DbHelper.instance;
-    final related = await db.fetchBooks(author: _book.author, unread: true);
+    final related = await db.fetchBooks(
+        author: _book.author, unread: true, orderBy: 'title');
     BookModel? next;
     for (final b in related) {
       if (b.id != id) {
@@ -163,7 +164,7 @@ class _ReaderScreenState extends State<ReaderScreen> {
         break;
       }
     }
-    final unread = await db.fetchBooks(unread: true);
+    final unread = await db.fetchBooks(unread: true, orderBy: 'title');
     final others = unread.where((b) => b.id != id).toList();
     others.shuffle();
     final random = others.isNotEmpty ? others.first : null;

--- a/test/db_helper_test.dart
+++ b/test/db_helper_test.dart
@@ -91,8 +91,8 @@ void main() {
     });
 
     test('delete book', () async {
-      final id = await dbHelper
-          .insertBook(BookModel(title: 'Del', path: '/tmp/a.cbz', language: 'en'));
+      final id = await dbHelper.insertBook(
+          BookModel(title: 'Del', path: '/tmp/a.cbz', language: 'en'));
       await dbHelper.deleteBook(id);
       final books = await dbHelper.fetchBooks();
       expect(books, isEmpty);
@@ -100,9 +100,18 @@ void main() {
 
     test('fetchBooks with filters', () async {
       await dbHelper.insertBook(BookModel(
-          title: 'A', path: '/tmp/a.cbz', language: 'en', author: 'Alice', tags: ['x']));
+          title: 'A',
+          path: '/tmp/a.cbz',
+          language: 'en',
+          author: 'Alice',
+          tags: ['x']));
       await dbHelper.insertBook(BookModel(
-          title: 'B', path: '/tmp/b.cbz', language: 'en', author: 'Bob', tags: ['y'], lastPage: 2));
+          title: 'B',
+          path: '/tmp/b.cbz',
+          language: 'en',
+          author: 'Bob',
+          tags: ['y'],
+          lastPage: 2));
 
       final tagFiltered = await dbHelper.fetchBooks(tags: ['x']);
       expect(tagFiltered.map((b) => b.title), ['A']);
@@ -116,9 +125,17 @@ void main() {
 
     test('fetchAllAuthors and fetchAllTags', () async {
       await dbHelper.insertBook(BookModel(
-          title: 'A', path: '/tmp/a.cbz', language: 'en', author: 'Me', tags: ['x','y']));
+          title: 'A',
+          path: '/tmp/a.cbz',
+          language: 'en',
+          author: 'Me',
+          tags: ['x', 'y']));
       await dbHelper.insertBook(BookModel(
-          title: 'B', path: '/tmp/b.cbz', language: 'en', author: 'You', tags: ['y']));
+          title: 'B',
+          path: '/tmp/b.cbz',
+          language: 'en',
+          author: 'You',
+          tags: ['y']));
 
       final authors = await dbHelper.fetchAllAuthors();
       expect(authors.toSet(), {'Me', 'You'});
@@ -138,8 +155,8 @@ void main() {
     });
 
     test('history insertion and fetch', () async {
-      final id = await dbHelper
-          .insertBook(BookModel(title: 'Hist', path: '/tmp/h.cbz', language: 'en'));
+      final id = await dbHelper.insertBook(
+          BookModel(title: 'Hist', path: '/tmp/h.cbz', language: 'en'));
       await dbHelper.updateProgress(id, 3);
       final history = await dbHelper.fetchHistory(id);
       expect(history, isNotEmpty);
@@ -147,8 +164,8 @@ void main() {
     });
 
     test('bookmark add and remove', () async {
-      final id = await dbHelper
-          .insertBook(BookModel(title: 'Bm', path: '/tmp/h.cbz', language: 'en'));
+      final id = await dbHelper.insertBook(
+          BookModel(title: 'Bm', path: '/tmp/h.cbz', language: 'en'));
       await dbHelper.addBookmark(id, 2);
       var bookmarks = await dbHelper.fetchBookmarks(id);
       expect(bookmarks, contains(2));
@@ -156,6 +173,5 @@ void main() {
       bookmarks = await dbHelper.fetchBookmarks(id);
       expect(bookmarks, isEmpty);
     });
-
   });
 }

--- a/test/library_screen_test.dart
+++ b/test/library_screen_test.dart
@@ -26,7 +26,7 @@ void main() {
   testWidgets('shows empty message with no books', (tester) async {
     await tester.pumpWidget(MaterialApp(
       home: LibraryScreen(
-        fetchBooks: ({tags, author, unread}) async => [],
+        fetchBooks: ({tags, author, unread, query, orderBy}) async => [],
       ),
     ));
     await tester.pump();
@@ -39,7 +39,7 @@ void main() {
     final books = [BookModel(title: 'A', path: '/tmp/a.cbz', language: 'en')];
     await tester.pumpWidget(MaterialApp(
       home: LibraryScreen(
-        fetchBooks: ({tags, author, unread}) async => books,
+        fetchBooks: ({tags, author, unread, query, orderBy}) async => books,
       ),
     ));
     await tester.pump();
@@ -52,7 +52,8 @@ void main() {
   testWidgets('toggles list and grid view', (tester) async {
     final books = [BookModel(title: 'B', path: '/tmp/b.cbz', language: 'en')];
     await tester.pumpWidget(MaterialApp(
-      home: LibraryScreen(fetchBooks: ({tags, author, unread}) async => books),
+      home: LibraryScreen(
+          fetchBooks: ({tags, author, unread, query, orderBy}) async => books),
     ));
     await tester.pumpAndSettle();
 
@@ -64,9 +65,12 @@ void main() {
   });
 
   testWidgets('shows delete dialog on long press', (tester) async {
-    final books = [BookModel(id: 1, title: 'X', path: '/tmp/x.cbz', language: 'en')];
+    final books = [
+      BookModel(id: 1, title: 'X', path: '/tmp/x.cbz', language: 'en')
+    ];
     await tester.pumpWidget(MaterialApp(
-      home: LibraryScreen(fetchBooks: ({tags, author, unread}) async => books),
+      home: LibraryScreen(
+          fetchBooks: ({tags, author, unread, query, orderBy}) async => books),
     ));
     await tester.pumpAndSettle();
 
@@ -76,9 +80,12 @@ void main() {
   });
 
   testWidgets('opens detail screen from menu', (tester) async {
-    final books = [BookModel(id: 1, title: 'E', path: '/tmp/e.cbz', language: 'en')];
+    final books = [
+      BookModel(id: 1, title: 'E', path: '/tmp/e.cbz', language: 'en')
+    ];
     await tester.pumpWidget(MaterialApp(
-      home: LibraryScreen(fetchBooks: ({tags, author, unread}) async => books),
+      home: LibraryScreen(
+          fetchBooks: ({tags, author, unread, query, orderBy}) async => books),
     ));
     await tester.pumpAndSettle();
 


### PR DESCRIPTION
## Summary
- allow searching titles from the library screen
- add dropdown to sort by title/author/recently read
- support query and orderBy in DbHelper
- adjust reader and tests for new fetchBooks signature

## Testing
- `flutter analyze` *(fails: version solving failed)*
- `flutter test` *(fails: version solving failed)*

------
https://chatgpt.com/codex/tasks/task_e_6889175dc3c48326a583f638f67d3f1b