### PR TITLE
Add bookmarks list in reader

### DIFF
--- a/lib/screens/bookmarks_screen.dart
+++ b/lib/screens/bookmarks_screen.dart
@@ -1,0 +1,42 @@
+import 'package:flutter/material.dart';
+
+import '../database/db_helper.dart';
+import '../models/book_model.dart';
+
+/// Lists bookmarked pages for a book and returns the selected page index.
+class BookmarksScreen extends StatelessWidget {
+  final BookModel book;
+  const BookmarksScreen({super.key, required this.book});
+
+  @override
+  Widget build(BuildContext context) {
+    final id = book.id;
+    return Scaffold(
+      appBar: AppBar(title: const Text('Bookmarks')),
+      body: id == null
+          ? const Center(child: Text('No bookmarks'))
+          : FutureBuilder<List<int>>(
+              future: DbHelper.instance.fetchBookmarks(id),
+              builder: (context, snapshot) {
+                if (!snapshot.hasData) {
+                  return const Center(child: CircularProgressIndicator());
+                }
+                final pages = snapshot.data!;
+                if (pages.isEmpty) {
+                  return const Center(child: Text('No bookmarks'));
+                }
+                return ListView.builder(
+                  itemCount: pages.length,
+                  itemBuilder: (context, index) {
+                    final p = pages[index];
+                    return ListTile(
+                      title: Text('Page ${p + 1}') ,
+                      onTap: () => Navigator.pop(context, p),
+                    );
+                  },
+                );
+              },
+            ),
+    );
+  }
+}

--- a/lib/screens/reader_screen.dart
+++ b/lib/screens/reader_screen.dart
@@ -5,6 +5,7 @@ import 'package:flutter/material.dart';
 
 import '../database/db_helper.dart';
 import '../models/book_model.dart';
+import 'bookmarks_screen.dart';
 
 /// Displays the pages of a book using [PageView] and remembers the last page
 /// read. Supports left-to-right or right-to-left reading direction, pinch zoom
@@ -212,6 +213,22 @@ class _ReaderScreenState extends State<ReaderScreen> {
     );
   }
 
+  Future<void> _openBookmarks() async {
+    final page = await Navigator.push<int>(
+      context,
+      MaterialPageRoute(
+        builder: (_) => BookmarksScreen(book: _book),
+      ),
+    );
+    if (page != null && mounted) {
+      final index = _doublePage ? (page / 2).floor() : page;
+      _controller.jumpToPage(index);
+      setState(() {
+        _currentPage = index;
+      });
+    }
+  }
+
   Widget _buildPage(int index) {
     final pages = _pagesForIndex(index);
     if (pages.length == 1) {
@@ -252,6 +269,17 @@ class _ReaderScreenState extends State<ReaderScreen> {
                     _controller = PageController(initialPage: newPage);
                     _currentPage = newPage;
                   }),
+                ),
+                PopupMenuButton<String>(
+                  onSelected: (value) {
+                    if (value == 'bookmarks') _openBookmarks();
+                  },
+                  itemBuilder: (_) => const [
+                    PopupMenuItem(
+                      value: 'bookmarks',
+                      child: Text('Bookmarks'),
+                    ),
+                  ],
                 ),
               ],
             )

--- a/test/reader_screen_test.dart
+++ b/test/reader_screen_test.dart
@@ -66,4 +66,20 @@ void main() {
     expect(find.byIcon(Icons.bookmark_border), findsOneWidget);
     expect(find.byType(Slider), findsOneWidget);
   });
+
+  testWidgets('opens bookmarks screen from menu', (tester) async {
+    final dir = Directory.systemTemp.createTempSync();
+    final imgPath = p.join(dir.path, 'a.png');
+    File(imgPath).writeAsBytesSync(base64Decode(
+        'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8Xw8AAiMB7g6lbYkAAAAASUVORK5CYII='));
+    final book = BookModel(title: 'Read', path: dir.path, language: 'en', pages: [imgPath]);
+    await tester.pumpWidget(MaterialApp(home: ReaderScreen(book: book)));
+
+    await tester.tap(find.byIcon(Icons.more_vert));
+    await tester.pumpAndSettle();
+    await tester.tap(find.text('Bookmarks'));
+    await tester.pumpAndSettle();
+
+    expect(find.text('No bookmarks'), findsOneWidget);
+  });
 }


### PR DESCRIPTION
## Summary
- add a `BookmarksScreen` for jumping to bookmarked pages
- open bookmarks screen from a new menu in `ReaderScreen`
- test bookmark menu behaviour

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68892174f108832684a19f94b3a44994