### PR TITLE
Add reading history screen

### DIFF
--- a/lib/database/db_helper.dart
+++ b/lib/database/db_helper.dart
@@ -237,6 +237,18 @@ class DbHelper {
     return db.query('history', where: 'book_id = ?', whereArgs: [bookId]);
   }
 
+  /// Returns books that have history entries ordered by most recent read.
+  Future<List<BookModel>> fetchHistoryBooks() async {
+    final db = await database;
+    final maps = await db.rawQuery('''
+      SELECT b.* FROM books b
+      JOIN history h ON b.id = h.book_id
+      GROUP BY b.id
+      ORDER BY MAX(h.timestamp) DESC
+    ''');
+    return maps.map((e) => BookModel.fromMap(e)).toList();
+  }
+
   Future<void> addBookmark(int bookId, int page) async {
     final db = await database;
     await db.insert('bookmarks', {'book_id': bookId, 'page': page});

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,5 +1,5 @@
 import 'package:flutter/material.dart';
-import 'screens/library_screen.dart';
+import 'screens/main_menu.dart';
 
 void main() => runApp(const ManaReaderApp());
 
@@ -11,7 +11,7 @@ class ManaReaderApp extends StatelessWidget {
     return MaterialApp(
       title: 'Mana Reader',
       theme: ThemeData.dark(),
-      home: const LibraryScreen(),
+      home: const MainMenu(),
     );
   }
 }

--- a/lib/screens/history_screen.dart
+++ b/lib/screens/history_screen.dart
@@ -1,0 +1,48 @@
+import 'package:flutter/material.dart';
+
+import '../database/db_helper.dart';
+import '../models/book_model.dart';
+import 'reader_screen.dart';
+
+/// Lists books sorted by recent reading history.
+class HistoryScreen extends StatelessWidget {
+  const HistoryScreen({super.key});
+
+  Future<List<BookModel>> _fetchHistory() {
+    return DbHelper.instance.fetchHistoryBooks();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(title: const Text('History')),
+      body: FutureBuilder<List<BookModel>>(
+        future: _fetchHistory(),
+        builder: (context, snapshot) {
+          if (!snapshot.hasData) {
+            return const Center(child: CircularProgressIndicator());
+          }
+          final books = snapshot.data!;
+          if (books.isEmpty) {
+            return const Center(child: Text('No history'));
+          }
+          return ListView.builder(
+            itemCount: books.length,
+            itemBuilder: (context, index) {
+              final book = books[index];
+              return ListTile(
+                title: Text(book.title),
+                onTap: () => Navigator.push(
+                  context,
+                  MaterialPageRoute(
+                    builder: (_) => ReaderScreen(book: book),
+                  ),
+                ),
+              );
+            },
+          );
+        },
+      ),
+    );
+  }
+}

--- a/lib/screens/library_screen.dart
+++ b/lib/screens/library_screen.dart
@@ -7,6 +7,7 @@ import '../models/book_model.dart';
 import '../import/importer.dart';
 import 'package:file_picker/file_picker.dart';
 import 'book_detail_screen.dart';
+import 'history_screen.dart';
 
 /// Displays the list of imported books.
 class LibraryScreen extends StatefulWidget {
@@ -35,6 +36,13 @@ class _LibraryScreenState extends State<LibraryScreen> {
   bool _isGrid = true;
   String _searchQuery = '';
   String _sortOrder = 'title';
+
+  void _openHistory() {
+    Navigator.push(
+      context,
+      MaterialPageRoute(builder: (_) => const HistoryScreen()),
+    );
+  }
 
   @override
   void initState() {
@@ -130,6 +138,10 @@ class _LibraryScreenState extends State<LibraryScreen> {
                 }
               },
             ),
+          ),
+          IconButton(
+            icon: const Icon(Icons.history),
+            onPressed: _openHistory,
           ),
           IconButton(
             icon: Icon(_isGrid ? Icons.view_list : Icons.grid_on),

--- a/lib/screens/main_menu.dart
+++ b/lib/screens/main_menu.dart
@@ -1,0 +1,38 @@
+import 'package:flutter/material.dart';
+
+import 'history_screen.dart';
+import 'library_screen.dart';
+
+/// Simple start screen offering navigation to major sections.
+class MainMenu extends StatelessWidget {
+  const MainMenu({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(title: const Text('Mana Reader')),
+      body: Center(
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            ElevatedButton(
+              onPressed: () => Navigator.push(
+                context,
+                MaterialPageRoute(builder: (_) => const LibraryScreen()),
+              ),
+              child: const Text('Library'),
+            ),
+            const SizedBox(height: 16),
+            ElevatedButton(
+              onPressed: () => Navigator.push(
+                context,
+                MaterialPageRoute(builder: (_) => const HistoryScreen()),
+              ),
+              child: const Text('History'),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}


### PR DESCRIPTION
## Summary
- add `HistoryScreen` for listing recently read books
- query recent books with `DbHelper.fetchHistoryBooks`
- link history from the library screen
- provide simple `MainMenu` and update app entry point

## Testing
- `dart format` *(fails: dart/flutter not installed)*
- `flutter analyze` *(fails: flutter not installed)*
- `flutter test` *(fails: flutter not installed)*

------
https://chatgpt.com/codex/tasks/task_e_6889245488d083268be265d214815f7b