### PR TITLE
Add reading progress indicator

### DIFF
--- a/lib/screens/history_screen.dart
+++ b/lib/screens/history_screen.dart
@@ -3,13 +3,49 @@ import 'package:flutter/material.dart';
 import '../database/db_helper.dart';
 import '../models/book_model.dart';
 import 'reader_screen.dart';
+import 'dart:io';
 
 /// Lists books sorted by recent reading history.
 class HistoryScreen extends StatelessWidget {
   const HistoryScreen({super.key});
 
+  final Map<String, Future<double>> _progressCache = {};
+
   Future<List<BookModel>> _fetchHistory() {
     return DbHelper.instance.fetchHistoryBooks();
+  }
+
+  Future<double> _progressFor(BookModel book) {
+    return _progressCache[book.path] ??= _loadProgress(book);
+  }
+
+  Future<double> _loadProgress(BookModel book) async {
+    int count = book.pages.length;
+    if (count == 0) {
+      final dir = Directory(book.path);
+      if (!await dir.exists()) return 0;
+      try {
+        final files = await dir
+            .list(recursive: true)
+            .where((e) => e is File && _isImage(e.path))
+            .toList();
+        files.sort();
+        count = files.length;
+      } catch (_) {
+        return 0;
+      }
+    }
+    if (count == 0) return 0;
+    final progress = book.lastPage / count;
+    return progress.clamp(0, 1).toDouble();
+  }
+
+  bool _isImage(String path) {
+    final lower = path.toLowerCase();
+    return lower.endsWith('.jpg') ||
+        lower.endsWith('.jpeg') ||
+        lower.endsWith('.png') ||
+        lower.endsWith('.gif');
   }
 
   @override
@@ -32,6 +68,17 @@ class HistoryScreen extends StatelessWidget {
               final book = books[index];
               return ListTile(
                 title: Text(book.title),
+                subtitle: FutureBuilder<double>(
+                  future: _progressFor(book),
+                  builder: (context, snap) {
+                    final value = snap.data ?? 0.0;
+                    return LinearProgressIndicator(
+                      value: value,
+                      minHeight: 4,
+                      backgroundColor: Colors.black26,
+                    );
+                  },
+                ),
                 onTap: () => Navigator.push(
                   context,
                   MaterialPageRoute(


### PR DESCRIPTION
## Summary
- compute book progress using lastPage and total pages
- overlay progress bar on library grid and list items
- show reading progress in history list

## Testing
- `apt-get update`
- ❌ `dart format lib/screens/library_screen.dart lib/screens/history_screen.dart`


------
https://chatgpt.com/codex/tasks/task_e_68892746474c83268dce7093e7629127