### PR TITLE
Add edge tap page navigation

### DIFF
--- a/lib/screens/reader_screen.dart
+++ b/lib/screens/reader_screen.dart
@@ -289,13 +289,43 @@ class _ReaderScreenState extends State<ReaderScreen> {
         textDirection: _isRtl ? TextDirection.rtl : TextDirection.ltr,
         child: Stack(
           children: [
-            GestureDetector(
-              onTap: () => setState(() => _showUI = !_showUI),
-              child: PageView.builder(
-                controller: _controller,
-                itemCount: _pageCount,
-                onPageChanged: _onPageChanged,
-                itemBuilder: (context, index) => _buildPage(index),
+            PageView.builder(
+              controller: _controller,
+              itemCount: _pageCount,
+              onPageChanged: _onPageChanged,
+              itemBuilder: (context, index) => _buildPage(index),
+            ),
+            Positioned.fill(
+              child: Row(
+                children: [
+                  Expanded(
+                    child: GestureDetector(
+                      key: const Key('previous_page_zone'),
+                      behavior: HitTestBehavior.translucent,
+                      onTap: () => _controller.previousPage(
+                        duration: const Duration(milliseconds: 200),
+                        curve: Curves.easeInOut,
+                      ),
+                    ),
+                  ),
+                  const Expanded(child: SizedBox.shrink()),
+                  Expanded(
+                    child: GestureDetector(
+                      key: const Key('next_page_zone'),
+                      behavior: HitTestBehavior.translucent,
+                      onTap: () => _controller.nextPage(
+                        duration: const Duration(milliseconds: 200),
+                        curve: Curves.easeInOut,
+                      ),
+                    ),
+                  ),
+                ],
+              ),
+            ),
+            Positioned.fill(
+              child: GestureDetector(
+                behavior: HitTestBehavior.translucent,
+                onTap: () => setState(() => _showUI = !_showUI),
               ),
             ),
             if (_showUI)

--- a/test/reader_screen_test.dart
+++ b/test/reader_screen_test.dart
@@ -103,4 +103,29 @@ void main() {
 
     expect(find.text('No bookmarks'), findsOneWidget);
   });
+
+  testWidgets('tapping right edge changes the page', (tester) async {
+    final dir = Directory.systemTemp.createTempSync();
+    final img1 = p.join(dir.path, 'a.png');
+    final img2 = p.join(dir.path, 'b.png');
+    final bytes = base64Decode(
+        'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8Xw8AAiMB7g6lbYkAAAAASUVORK5CYII=');
+    File(img1).writeAsBytesSync(bytes);
+    File(img2).writeAsBytesSync(bytes);
+    final book = BookModel(title: 'Read', path: dir.path, language: 'en', pages: [img1, img2]);
+    await tester.pumpWidget(MaterialApp(
+      localizationsDelegates: AppLocalizations.localizationsDelegates,
+      supportedLocales: AppLocalizations.supportedLocales,
+      home: ReaderScreen(book: book),
+    ));
+
+    Slider slider = tester.widget(find.byType(Slider));
+    expect(slider.value, 0);
+
+    await tester.tap(find.byKey(const Key('next_page_zone')));
+    await tester.pumpAndSettle();
+
+    slider = tester.widget(find.byType(Slider));
+    expect(slider.value, 1);
+  });
 }


### PR DESCRIPTION
## Summary
- add transparent zones to ReaderScreen for page navigation
- keep UI toggle tap detection
- verify tapping edge changes page

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6889668edad08326ae60edd8e744cfb0