### PR TITLE
Add fit mode toggle for reader

### DIFF
--- a/lib/l10n/intl_en.arb
+++ b/lib/l10n/intl_en.arb
@@ -28,5 +28,6 @@
   "randomUnread": "Random Unread",
   "bookDetails": "Book Details",
   "language": "Language",
-  "tagsCommaSeparated": "Tags (comma separated)"
+  "tagsCommaSeparated": "Tags (comma separated)",
+  "fitWidth": "Fit Width"
 }


### PR DESCRIPTION
## Summary
- add `FitMode` enum and store selected mode in reader screen
- provide button in the app bar to switch between fit modes
- pass fit mode to `_ZoomableImage`
- extend `_ZoomableImage` with a `fit` parameter
- add "Fit Width" label to localization

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6889680aee3c8326a707fa9e92bbba41