### PR TITLE
Add directory sync action

### DIFF
--- a/lib/import/sync_service.dart
+++ b/lib/import/sync_service.dart
@@ -1,0 +1,40 @@
+import 'dart:io';
+
+import 'package:path/path.dart' as p;
+import 'package:path_provider/path_provider.dart';
+
+import '../database/db_helper.dart';
+import 'importer.dart';
+
+/// Scans [dirPath] for supported archives and imports any that are not already present in the database.
+Future<void> syncDirectoryPath(String dirPath, {DbHelper? dbHelper}) async {
+  final directory = Directory(dirPath);
+  if (!await directory.exists()) return;
+
+  final db = dbHelper ?? DbHelper.instance;
+  final books = await db.fetchBooks();
+  final existingPaths = books.map((b) => b.path).toSet();
+
+  final docs = await getApplicationDocumentsDirectory();
+  final importer = Importer(dbHelper: db);
+
+  await for (final entity in directory.list(recursive: true)) {
+    if (entity is! File) continue;
+    final lower = entity.path.toLowerCase();
+    if (!(lower.endsWith('.cbz') ||
+        lower.endsWith('.cbr') ||
+        lower.endsWith('.cb7') ||
+        lower.endsWith('.pdf'))) {
+      continue;
+    }
+    final baseName = p.basenameWithoutExtension(entity.path);
+    final destPath = p.join(docs.path, 'books', baseName);
+    if (existingPaths.contains(destPath)) continue;
+    try {
+      await importer.importPath(entity.path);
+      existingPaths.add(destPath);
+    } catch (_) {
+      // Ignore individual import failures
+    }
+  }
+}

--- a/lib/screens/library_screen.dart
+++ b/lib/screens/library_screen.dart
@@ -6,7 +6,10 @@ import '../database/db_helper.dart';
 import '../models/book_model.dart';
 
 import '../import/importer.dart';
+import '../import/sync_service.dart';
 import 'package:file_picker/file_picker.dart';
+import 'package:path/path.dart' as p;
+import 'package:path_provider/path_provider.dart';
 import 'book_detail_screen.dart';
 import 'history_screen.dart';
 
@@ -162,6 +165,10 @@ class _LibraryScreenState extends State<LibraryScreen> {
           IconButton(
             icon: const Icon(Icons.history),
             onPressed: _openHistory,
+          ),
+          IconButton(
+            icon: const Icon(Icons.sync),
+            onPressed: _syncDirectory,
           ),
           IconButton(
             icon: Icon(_isGrid ? Icons.view_list : Icons.grid_on),
@@ -460,6 +467,27 @@ class _LibraryScreenState extends State<LibraryScreen> {
       final importer = Importer();
       await importer.importPath(path);
       _loadBooks();
+    } catch (e) {
+      if (context.mounted) {
+        ScaffoldMessenger.of(
+          context,
+        ).showSnackBar(
+          SnackBar(
+            content: Text(
+              AppLocalizations.of(context)!.importFailed(error: e.toString()),
+            ),
+          ),
+        );
+      }
+    }
+  }
+
+  Future<void> _syncDirectory() async {
+    final path = await FilePicker.platform.getDirectoryPath();
+    if (path == null) return;
+    try {
+      await syncDirectoryPath(path);
+      if (mounted) _loadBooks();
     } catch (e) {
       if (context.mounted) {
         ScaffoldMessenger.of(

--- a/test/sync_service_test.dart
+++ b/test/sync_service_test.dart
@@ -1,0 +1,199 @@
+import 'dart:convert';
+import 'dart:io';
+import 'dart:async';
+import 'dart:ffi';
+import 'dart:typed_data';
+import 'dart:ui' as ui;
+
+import 'package:flutter/services.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:path/path.dart' as p;
+import 'package:path_provider_platform_interface/path_provider_platform_interface.dart';
+import 'package:sqflite_common_ffi/sqflite_ffi.dart';
+import 'package:archive/archive.dart';
+import 'package:pdf_render/pdf_render.dart';
+
+import 'package:mana_reader/import/sync_service.dart';
+import 'package:mana_reader/database/db_helper.dart';
+
+class _FakePdfRenderPlatform extends PdfRenderPlatform {
+  @override
+  Future<PdfDocument> openFile(String filePath) async => _FakePdfDocument();
+
+  @override
+  Future<PdfDocument> openAsset(String name) async => _FakePdfDocument();
+
+  @override
+  Future<PdfDocument> openData(Uint8List data) async => _FakePdfDocument();
+
+  @override
+  Future<PdfPageImageTexture> createTexture({required FutureOr<PdfDocument> pdfDocument, required int pageNumber}) =>
+      throw UnimplementedError();
+}
+
+class _FakePdfDocument extends PdfDocument {
+  _FakePdfDocument()
+      : super(
+            sourceName: 'fake.pdf',
+            pageCount: 1,
+            verMajor: 1,
+            verMinor: 7,
+            isEncrypted: false,
+            allowsCopying: true,
+            allowsPrinting: true);
+
+  @override
+  Future<void> dispose() async {}
+
+  @override
+  Future<PdfPage> getPage(int pageNumber) async => _FakePdfPage(this, pageNumber);
+
+  @override
+  bool operator ==(dynamic other) => identical(this, other);
+
+  @override
+  int get hashCode => super.hashCode;
+}
+
+class _FakePdfPage extends PdfPage {
+  _FakePdfPage(PdfDocument doc, int num)
+      : super(document: doc, pageNumber: num, width: 1, height: 1);
+
+  @override
+  Future<PdfPageImage> render({
+    int x = 0,
+    int y = 0,
+    int? width,
+    int? height,
+    double? fullWidth,
+    double? fullHeight,
+    bool backgroundFill = true,
+    bool allowAntialiasingIOS = false,
+  }) async {
+    return _FakePdfPageImage(pageNumber);
+  }
+
+  Future<void> close() async {}
+}
+
+class _FakePdfPageImage extends PdfPageImage {
+  _FakePdfPageImage(int page)
+      : _pixels = Uint8List.fromList(const [255, 0, 0, 255]),
+        super(
+            pageNumber: page,
+            x: 0,
+            y: 0,
+            width: 1,
+            height: 1,
+            fullWidth: 1,
+            fullHeight: 1,
+            pageWidth: 1,
+            pageHeight: 1);
+
+  final Uint8List _pixels;
+  ui.Image? _image;
+
+  @override
+  Uint8List get pixels => _pixels;
+
+  @override
+  Pointer<Uint8>? get buffer => null;
+
+  @override
+  void dispose() {}
+
+  @override
+  ui.Image? get imageIfAvailable => _image;
+
+  @override
+  Future<ui.Image> createImageIfNotAvailable() async {
+    if (_image != null) return _image!;
+    final comp = Completer<ui.Image>();
+    ui.decodeImageFromPixels(
+        _pixels, 1, 1, ui.PixelFormat.rgba8888, (img) => comp.complete(img));
+    _image = await comp.future;
+    return _image!;
+  }
+
+  @override
+  Future<ui.Image> createImageDetached() async => await createImageIfNotAvailable();
+}
+
+class _FakePathProviderPlatform extends PathProviderPlatform {
+  final Directory tempDir = Directory.systemTemp.createTempSync('mana_reader_test');
+
+  @override
+  Future<String?> getApplicationDocumentsPath() async => tempDir.path;
+}
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+  sqfliteFfiInit();
+  databaseFactory = databaseFactoryFfi;
+  PathProviderPlatform.instance = _FakePathProviderPlatform();
+
+  const imgData = 'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8Xw8AAiMB7g6lbYkAAAAASUVORK5CYII=';
+
+  setUp(() {
+    PathProviderPlatform.instance = _FakePathProviderPlatform();
+    PdfRenderPlatform.instance = _FakePdfRenderPlatform();
+    processRun = (String exe, List<String> args) async {
+      if (exe == 'which' || exe == 'where') {
+        return ProcessResult(0, 0, '', '');
+      }
+      if (exe == '7z') {
+        final archivePath = args[1];
+        var destArg = args[2];
+        if (destArg.startsWith('-o')) {
+          destArg = destArg.substring(2);
+        }
+        final bytes = File(archivePath).readAsBytesSync();
+        final archive = ZipDecoder().decodeBytes(bytes);
+        for (final f in archive) {
+          if (f.isFile) {
+            final out = File(p.join(destArg, f.name))..createSync(recursive: true);
+            out.writeAsBytesSync(f.content as List<int>);
+          }
+        }
+        return ProcessResult(0, 0, '', '');
+      }
+      throw UnsupportedError(exe);
+    };
+
+    const MethodChannel('com.lkrjangid.rar').setMockMethodCallHandler((call) async {
+      if (call.method == 'extractRarFile') {
+        final bytes = File(call.arguments['rarFilePath'] as String).readAsBytesSync();
+        final archive = ZipDecoder().decodeBytes(bytes);
+        final dest = call.arguments['destinationPath'] as String;
+        for (final f in archive) {
+          if (f.isFile) {
+            final out = File(p.join(dest, f.name))..createSync(recursive: true);
+            out.writeAsBytesSync(f.content as List<int>);
+          }
+        }
+        return {'success': true, 'message': 'ok'};
+      }
+      return null;
+    });
+  });
+
+  test('syncDirectoryPath imports all archives', () async {
+    final tmp = Directory.systemTemp.createTempSync();
+    final img = base64Decode(imgData);
+
+    // Create zip archive
+    final zipArchive = Archive()..addFile(ArchiveFile('a.png', img.length, img));
+    final zipBytes = ZipEncoder().encode(zipArchive)!;
+    File(p.join(tmp.path, 'a.cbz')).writeAsBytesSync(zipBytes);
+    File(p.join(tmp.path, 'b.cbr')).writeAsBytesSync(zipBytes);
+    File(p.join(tmp.path, 'c.cb7')).writeAsBytesSync(zipBytes);
+
+    final pdfData = base64Decode('JVBERi0xLjEKMSAwIG9iajw8L1R5cGUvQ2F0YWxvZy9QYWdlcyAyIDAgUj4+ZW5kb2JqCjIgMCBvYmo8PC9UeXBlL1BhZ2VzL0tpZHNbMyAwIFJdL0NvdW50IDE+PmVuZG9iagozIDAgb2JqPDwvVHlwZS9QYWdlL1BhcmVudCAyIDAgUi9NZWRpYUJveFswIDAgNjEyIDc5Ml0+PmVuZG9iagp0cmFpbGVyPDwvUm9vdCAxIDAgUi9TaXplIDQ+PgolJUVPRg==');
+    File(p.join(tmp.path, 'd.pdf')).writeAsBytesSync(pdfData);
+
+    final db = DbHelper();
+    await syncDirectoryPath(tmp.path, dbHelper: db);
+    final books = await db.fetchBooks();
+    expect(books, hasLength(4));
+  });
+}


### PR DESCRIPTION
## Summary
- implement directory scan in `syncDirectoryPath`
- trigger syncing via new AppBar button
- refresh the library after syncing
- test directory sync with multiple archive types

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6889730d7f208326b6d66d26a060e4e4