### PR TITLE
Add favorites feature

### DIFF
--- a/lib/models/book_model.dart
+++ b/lib/models/book_model.dart
@@ -7,6 +7,7 @@ class BookModel {
   final List<String> tags;
   final int lastPage;
   final List<String> pages;
+  final bool favorite;
 
   BookModel({
     this.id,
@@ -17,6 +18,7 @@ class BookModel {
     this.tags = const [],
     this.lastPage = 0,
     this.pages = const [],
+    this.favorite = false,
   });
 
   Map<String, dynamic> toMap() {
@@ -28,6 +30,7 @@ class BookModel {
       'language': language,
       'tags': tags.join(','),
       'last_page': lastPage,
+      'favorite': favorite ? 1 : 0,
     }..removeWhere((key, value) => value == null);
   }
 
@@ -40,6 +43,7 @@ class BookModel {
       language: map['language'] as String? ?? 'unknown',
       tags: (map['tags'] as String? ?? '').split(',').where((t) => t.isNotEmpty).toList(),
       lastPage: map['last_page'] as int? ?? 0,
+      favorite: (map['favorite'] as int? ?? 0) == 1,
     );
   }
 }

--- a/lib/screens/library_screen.dart
+++ b/lib/screens/library_screen.dart
@@ -40,6 +40,7 @@ class _LibraryScreenState extends State<LibraryScreen> {
   String? _selectedAuthor;
   String? _selectedLanguage;
   bool _showUnread = false;
+  bool _showFavorites = false;
   bool _isGrid = true;
   String _searchQuery = '';
   String _sortOrder = 'title';
@@ -67,6 +68,7 @@ class _LibraryScreenState extends State<LibraryScreen> {
         author: _selectedAuthor,
         language: _selectedLanguage,
         unread: _showUnread ? true : null,
+        favorite: _showFavorites ? true : null,
         query: _searchQuery.isNotEmpty ? _searchQuery : null,
         orderBy: _sortOrder,
       );
@@ -237,6 +239,23 @@ class _LibraryScreenState extends State<LibraryScreen> {
                           },
                         ),
                         Positioned(
+                          top: 4,
+                          left: 4,
+                          child: IconButton(
+                            icon: Icon(
+                              book.favorite ? Icons.star : Icons.star_border,
+                              color: Colors.amber,
+                            ),
+                            onPressed: () async {
+                              if (book.id != null) {
+                                await DbHelper.instance
+                                    .toggleFavorite(book.id!, !book.favorite);
+                                _loadBooks();
+                              }
+                            },
+                          ),
+                        ),
+                        Positioned(
                           left: 0,
                           right: 0,
                           bottom: 0,
@@ -320,6 +339,19 @@ class _LibraryScreenState extends State<LibraryScreen> {
                                   fontSize: 12, color: Colors.white),
                             ),
                           );
+                        },
+                      ),
+                      IconButton(
+                        icon: Icon(
+                          book.favorite ? Icons.star : Icons.star_border,
+                          color: Colors.amber,
+                        ),
+                        onPressed: () async {
+                          if (book.id != null) {
+                            await DbHelper.instance
+                                .toggleFavorite(book.id!, !book.favorite);
+                            _loadBooks();
+                          }
                         },
                       ),
                       PopupMenuButton<String>(
@@ -429,6 +461,14 @@ class _LibraryScreenState extends State<LibraryScreen> {
                             },
                           ),
                           Text(AppLocalizations.of(context)!.unread),
+                          IconButton(
+                            icon: Icon(
+                                _showFavorites ? Icons.star : Icons.star_border),
+                            onPressed: () {
+                              setState(() => _showFavorites = !_showFavorites);
+                              _loadBooks();
+                            },
+                          ),
                         ],
                       ),
                     ],

--- a/test/db_helper_test.dart
+++ b/test/db_helper_test.dart
@@ -123,6 +123,17 @@ void main() {
       expect(unread.map((b) => b.title), ['A']);
     });
 
+    test('favorite toggle and filtering', () async {
+      final id = await dbHelper.insertBook(
+          BookModel(title: 'Fav', path: '/tmp/f.cbz', language: 'en'));
+      await dbHelper.toggleFavorite(id, true);
+      var favs = await dbHelper.fetchBooks(favorite: true);
+      expect(favs.map((b) => b.id), contains(id));
+      await dbHelper.toggleFavorite(id, false);
+      favs = await dbHelper.fetchBooks(favorite: true);
+      expect(favs, isEmpty);
+    });
+
     test('fetchAllAuthors and fetchAllTags', () async {
       await dbHelper.insertBook(BookModel(
           title: 'A',

--- a/test/library_screen_test.dart
+++ b/test/library_screen_test.dart
@@ -144,4 +144,23 @@ void main() {
     expect(find.text('EN'), findsNothing);
     expect(find.text('JP'), findsOneWidget);
   });
+
+  testWidgets('favorite filter button', (tester) async {
+    bool? receivedFavorite;
+    final books = [BookModel(title: 'F', path: '/tmp/f.cbz', language: 'en')];
+    await tester.pumpWidget(MaterialApp(
+      localizationsDelegates: AppLocalizations.localizationsDelegates,
+      supportedLocales: AppLocalizations.supportedLocales,
+      home: LibraryScreen(fetchBooks: ({favorite, tags, author, language, unread, query, orderBy}) async {
+        receivedFavorite = favorite;
+        return books;
+      }),
+    ));
+    await tester.pumpAndSettle();
+
+    expect(receivedFavorite, isNull);
+    await tester.tap(find.byIcon(Icons.star_border));
+    await tester.pumpAndSettle();
+    expect(receivedFavorite, isTrue);
+  });
 }


### PR DESCRIPTION
## Summary
- support a `favorite` flag in the `BookModel`
- add a favorite column and toggle helper in the DB layer
- allow filtering and toggling favorites in the library UI
- extend tests for favorite handling

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68897f2f75448326961c35e48ab8caf0