### PR TITLE
Cleanup book deletion logic

### DIFF
--- a/lib/screens/library_screen.dart
+++ b/lib/screens/library_screen.dart
@@ -527,12 +527,6 @@ class _LibraryScreenState extends State<LibraryScreen> {
 
     if (confirm == true) {
       await DbHelper.instance.deleteBook(book.id!);
-      try {
-        final dir = Directory(book.path);
-        if (await dir.exists()) {
-          await dir.delete(recursive: true);
-        }
-      } catch (_) {}
       if (mounted) _loadBooks();
     }
   }

--- a/test/db_helper_test.dart
+++ b/test/db_helper_test.dart
@@ -90,12 +90,17 @@ void main() {
       expect(fetched.tags, equals(['tag']));
     });
 
-    test('delete book', () async {
+    test('delete book removes files', () async {
+      final dir = Directory.systemTemp.createTempSync('mana_reader_book');
+      File('${dir.path}/page1.txt').writeAsStringSync('dummy');
       final id = await dbHelper.insertBook(
-          BookModel(title: 'Del', path: '/tmp/a.cbz', language: 'en'));
+          BookModel(title: 'Del', path: dir.path, language: 'en'));
+
       await dbHelper.deleteBook(id);
+
       final books = await dbHelper.fetchBooks();
       expect(books, isEmpty);
+      expect(await dir.exists(), isFalse);
     });
 
     test('fetchBooks with filters', () async {


### PR DESCRIPTION
## Summary
- let DbHelper.deleteBook handle book directory cleanup
- test DbHelper.deleteBook removes book files

## Testing
- `dart test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_688fbb1b3d5483268b8e23a1d0302709