### PR TITLE
Fetch filters concurrently

### DIFF
--- a/lib/screens/library_screen.dart
+++ b/lib/screens/library_screen.dart
@@ -76,14 +76,16 @@ class _LibraryScreenState extends State<LibraryScreen> {
   }
 
   Future<void> _initFilters() async {
-    final tags = await DbHelper.instance.fetchAllTags();
-    final authors = await DbHelper.instance.fetchAllAuthors();
-    final languages = await DbHelper.instance.fetchAllLanguages();
+    final results = await Future.wait<List<String>>([
+      DbHelper.instance.fetchAllTags(),
+      DbHelper.instance.fetchAllAuthors(),
+      DbHelper.instance.fetchAllLanguages(),
+    ]);
     if (!mounted) return;
     setState(() {
-      _tags = tags;
-      _authors = authors;
-      _languages = languages;
+      _tags = results[0];
+      _authors = results[1];
+      _languages = results[2];
     });
   }
 


### PR DESCRIPTION
## Summary
- optimize library filter initialization by fetching tags, authors, and languages in parallel

## Testing
- `flutter test` *(fails: command not found)*


------
https://chatgpt.com/codex/tasks/task_e_688fbdf206fc8326973c28e12ae27f55