### PR TITLE
Use onGenerateTitle for localized title

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -11,7 +11,7 @@ class ManaReaderApp extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return MaterialApp(
-      title: AppLocalizations.of(context)?.appTitle ?? 'Mana Reader',
+      onGenerateTitle: (context) => AppLocalizations.of(context)!.appTitle,
       theme: ThemeData.dark(),
       localizationsDelegates: AppLocalizations.localizationsDelegates,
       supportedLocales: AppLocalizations.supportedLocales,


### PR DESCRIPTION
## Summary
- derive app title from localizations via `onGenerateTitle`

## Testing
- `dart format lib/main.dart` *(fails: command not found)*
- `apt-get install -y dart` *(fails: unable to locate package)*
- `flutter test` *(fails: command not found)*
- `apt-get install -y flutter` *(fails: unable to locate package)*

------
https://chatgpt.com/codex/tasks/task_e_688fbefa0a248326bf4f476b99d8bf6d