### PR TITLE
Log and propagate metadata provider errors

### DIFF
--- a/lib/metadata/anilist_provider.dart
+++ b/lib/metadata/anilist_provider.dart
@@ -1,4 +1,6 @@
 import 'dart:convert';
+
+import 'package:flutter/foundation.dart';
 import 'package:http/http.dart' as http;
 
 import 'metadata_provider.dart';
@@ -45,8 +47,10 @@ class AniListProvider implements MetadataProvider {
           <String>[];
 
       return Metadata(title: title, language: lang, tags: tags);
-    } catch (_) {
-      return null;
+    } catch (e, st) {
+      debugPrint('AniListProvider search error: $e');
+      debugPrintStack(stackTrace: st);
+      rethrow;
     }
   }
 }

--- a/lib/metadata/doujindb_provider.dart
+++ b/lib/metadata/doujindb_provider.dart
@@ -1,4 +1,6 @@
 import 'dart:convert';
+
+import 'package:flutter/foundation.dart';
 import 'package:http/http.dart' as http;
 
 import 'metadata_provider.dart';
@@ -26,8 +28,10 @@ class DoujinDbProvider implements MetadataProvider {
       final tags = (first['tags'] as List?)?.cast<String>() ?? <String>[];
 
       return Metadata(title: title, language: lang, tags: tags);
-    } catch (_) {
-      return null;
+    } catch (e, st) {
+      debugPrint('DoujinDbProvider search error: $e');
+      debugPrintStack(stackTrace: st);
+      rethrow;
     }
   }
 }


### PR DESCRIPTION
## Summary
- log exceptions in AniListProvider and DoujinDbProvider using `debugPrint`
- rethrow errors to propagate them to the UI for user notifications

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_688fc9a29eb883269e9e055f630d5573