### PR TITLE
Handle partial import failures

### DIFF
--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -17,6 +17,7 @@
   "delete": "Delete",
   "edit": "Edit",
   "importFailed": "Import failed: {error}",
+  "importPartialFailure": "Some items failed to import",
   "bookmarks": "Bookmarks",
   "noBookmarks": "No bookmarks",
   "pageWithNumber": "Page {page}",

--- a/lib/screens/library_screen.dart
+++ b/lib/screens/library_screen.dart
@@ -569,8 +569,17 @@ class _LibraryScreenState extends State<LibraryScreen> {
     final path = await FilePicker.platform.getDirectoryPath();
     if (path == null) return;
     try {
-      await syncDirectoryPath(path);
+      final success = await syncDirectoryPath(path);
       if (mounted) _loadBooks();
+      if (!success && context.mounted) {
+        ScaffoldMessenger.of(context).showSnackBar(
+          SnackBar(
+            content: Text(
+              AppLocalizations.of(context)!.importPartialFailure,
+            ),
+          ),
+        );
+      }
     } catch (e) {
       if (context.mounted) {
         ScaffoldMessenger.of(

--- a/test/sync_service_test.dart
+++ b/test/sync_service_test.dart
@@ -193,7 +193,8 @@ void main() {
     File(p.join(tmp.path, 'e.pdf')).writeAsBytesSync(pdfData);
 
     final db = DbHelper();
-    await syncDirectoryPath(tmp.path, dbHelper: db);
+    final success = await syncDirectoryPath(tmp.path, dbHelper: db);
+    expect(success, isTrue);
     final books = await db.fetchBooks();
     expect(books, hasLength(5));
   });


### PR DESCRIPTION
## Summary
- Log individual import failures in `syncDirectoryPath` and report overall success
- Show a snackbar when batch imports partially fail
- Add translation for partial import warnings and adjust tests

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_688fdf336768832687871a65bc5a0f42