### PR TITLE
Handle image precache errors

### DIFF
--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -32,5 +32,6 @@
   "tagsCommaSeparated": "Tags (comma separated)",
   "fitWidth": "Fit Width",
   "clear": "Clear",
+  "pageLoadFailed": "Failed to load page {page}",
   "continueReading": "Continue Reading"
 }


### PR DESCRIPTION
## Summary
- log image precache failures and disable further preloading
- show localized message when a page fails to load

## Testing
- `dart format lib/screens/reader_screen.dart lib/l10n/app_en.arb` *(fails: app_en.arb not formatted)*
- `flutter test test/sync_service_test.dart` *(fails: Type 'PdfRenderPlatform' not found)*

------
https://chatgpt.com/codex/tasks/task_e_688fe53362548326b155d766c0a00497