### PR TITLE
Gracefully handle metadata provider failures

### DIFF
--- a/lib/database/db_helper.dart
+++ b/lib/database/db_helper.dart
@@ -176,6 +176,9 @@ class DbHelper {
   Future<int> importBook(String path, MetadataService service) async {
     final name = p.basenameWithoutExtension(path);
     final meta = await service.resolve(name);
+    if (meta == null) {
+      debugPrint('Metadata lookup failed for "$name"');
+    }
 
     final book = BookModel(
       title: meta?.title ?? name,

--- a/lib/import/importer.dart
+++ b/lib/import/importer.dart
@@ -1,3 +1,5 @@
+import 'package:flutter/foundation.dart';
+
 import '../database/db_helper.dart';
 import '../importers/importer_factory.dart';
 import '../models/book_model.dart';
@@ -17,6 +19,9 @@ class Importer {
     final book = await inner.import(path);
 
     final meta = await _metadata.resolve(book.title);
+    if (meta == null) {
+      debugPrint('Metadata lookup failed for "${book.title}"');
+    }
     final merged = BookModel(
       title: meta?.title ?? book.title,
       path: book.path,

--- a/lib/metadata/anilist_provider.dart
+++ b/lib/metadata/anilist_provider.dart
@@ -50,7 +50,7 @@ class AniListProvider implements MetadataProvider {
     } catch (e, st) {
       debugPrint('AniListProvider search error: $e');
       debugPrintStack(stackTrace: st);
-      rethrow;
+      return null;
     }
   }
 }

--- a/lib/metadata/doujindb_provider.dart
+++ b/lib/metadata/doujindb_provider.dart
@@ -31,7 +31,7 @@ class DoujinDbProvider implements MetadataProvider {
     } catch (e, st) {
       debugPrint('DoujinDbProvider search error: $e');
       debugPrintStack(stackTrace: st);
-      rethrow;
+      return null;
     }
   }
 }


### PR DESCRIPTION
## Summary
- Return null instead of rethrowing in AniList and DoujinDB metadata providers after logging errors
- Log metadata lookup failures and use fallback data when importing books

## Testing
- `flutter test` *(fails: command not found)*
- `dart test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_688fe878f8d8832690412f56e1b3fe5e