### PR TITLE
Use positional pageWithNumber argument

### DIFF
--- a/lib/screens/bookmarks_screen.dart
+++ b/lib/screens/bookmarks_screen.dart
@@ -24,14 +24,17 @@ class BookmarksScreen extends StatelessWidget {
                 }
                 final pages = snapshot.data!;
                 if (pages.isEmpty) {
-                  return Center(child: Text(AppLocalizations.of(context)!.noBookmarks));
+                  return Center(
+                      child: Text(AppLocalizations.of(context)!.noBookmarks));
                 }
                 return ListView.builder(
                   itemCount: pages.length,
                   itemBuilder: (context, index) {
                     final p = pages[index];
                     return ListTile(
-                      title: Text(AppLocalizations.of(context)!.pageWithNumber(page: p + 1)),
+                      title: Text(
+                        AppLocalizations.of(context)!.pageWithNumber(p + 1),
+                      ),
                       onTap: () => Navigator.pop(context, p),
                     );
                   },


### PR DESCRIPTION
## Summary
- use new positional argument for `pageWithNumber` when building bookmark list

## Testing
- `flutter analyze` *(fails: undefined methods and parameters in unrelated files)*
- `flutter test` *(fails: compilation and runtime errors in tests)*


------
https://chatgpt.com/codex/tasks/task_e_6890bb3eb7ac8326849ce32c4889aa52