### PR TITLE
Add favorite filter to fetchBooks interface

### DIFF
--- a/lib/screens/library_screen.dart
+++ b/lib/screens/library_screen.dart
@@ -21,6 +21,7 @@ class LibraryScreen extends StatefulWidget {
     String? author,
     String? language,
     bool? unread,
+    bool? favorite,
     String? query,
     String? orderBy,
   })?

--- a/test/library_screen_test.dart
+++ b/test/library_screen_test.dart
@@ -31,7 +31,7 @@ void main() {
       localizationsDelegates: AppLocalizations.localizationsDelegates,
       supportedLocales: AppLocalizations.supportedLocales,
       home: LibraryScreen(
-        fetchBooks: ({tags, author, language, unread, query, orderBy}) async => [],
+        fetchBooks: ({tags, author, language, unread, favorite, query, orderBy}) async => [],
       ),
     ));
     await tester.pump();
@@ -46,7 +46,7 @@ void main() {
       localizationsDelegates: AppLocalizations.localizationsDelegates,
       supportedLocales: AppLocalizations.supportedLocales,
       home: LibraryScreen(
-        fetchBooks: ({tags, author, language, unread, query, orderBy}) async => books,
+        fetchBooks: ({tags, author, language, unread, favorite, query, orderBy}) async => books,
       ),
     ));
     await tester.pump();
@@ -62,7 +62,7 @@ void main() {
       localizationsDelegates: AppLocalizations.localizationsDelegates,
       supportedLocales: AppLocalizations.supportedLocales,
       home: LibraryScreen(
-          fetchBooks: ({tags, author, language, unread, query, orderBy}) async => books),
+          fetchBooks: ({tags, author, language, unread, favorite, query, orderBy}) async => books),
     ));
     await tester.pumpAndSettle();
 
@@ -81,7 +81,7 @@ void main() {
       localizationsDelegates: AppLocalizations.localizationsDelegates,
       supportedLocales: AppLocalizations.supportedLocales,
       home: LibraryScreen(
-          fetchBooks: ({tags, author, language, unread, query, orderBy}) async => books),
+          fetchBooks: ({tags, author, language, unread, favorite, query, orderBy}) async => books),
     ));
     await tester.pumpAndSettle();
 
@@ -96,7 +96,7 @@ void main() {
     ];
     await tester.pumpWidget(MaterialApp(
       home: LibraryScreen(
-          fetchBooks: ({tags, author, language, unread, query, orderBy}) async => books),
+          fetchBooks: ({tags, author, language, unread, favorite, query, orderBy}) async => books),
     ));
     await tester.pumpAndSettle();
 
@@ -126,7 +126,7 @@ void main() {
       localizationsDelegates: AppLocalizations.localizationsDelegates,
       supportedLocales: AppLocalizations.supportedLocales,
       home: LibraryScreen(
-        fetchBooks: ({tags, author, language, unread, query, orderBy}) async {
+        fetchBooks: ({tags, author, language, unread, favorite, query, orderBy}) async {
           return books.where((b) => language == null || b.language == language).toList();
         },
       ),
@@ -151,7 +151,7 @@ void main() {
     await tester.pumpWidget(MaterialApp(
       localizationsDelegates: AppLocalizations.localizationsDelegates,
       supportedLocales: AppLocalizations.supportedLocales,
-      home: LibraryScreen(fetchBooks: ({favorite, tags, author, language, unread, query, orderBy}) async {
+      home: LibraryScreen(fetchBooks: ({tags, author, language, unread, favorite, query, orderBy}) async {
         receivedFavorite = favorite;
         return books;
       }),
@@ -186,7 +186,7 @@ void main() {
       localizationsDelegates: AppLocalizations.localizationsDelegates,
       supportedLocales: AppLocalizations.supportedLocales,
       home: LibraryScreen(
-        fetchBooks: ({tags, author, language, unread, query, orderBy}) async {
+        fetchBooks: ({tags, author, language, unread, favorite, query, orderBy}) async {
           return books.where((b) {
             if (tags != null && tags.isNotEmpty) {
               for (final t in tags) {


### PR DESCRIPTION
## Summary
- allow LibraryScreen fetchBooks to filter favorites via bool? favorite
- align library_screen tests with new argument

## Testing
- `flutter analyze` *(fails: command not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6890c1f984048326a9573236ee478e01