### PR TITLE
Remove unnecessary const before HistoryScreen

### DIFF
--- a/lib/screens/library_screen.dart
+++ b/lib/screens/library_screen.dart
@@ -50,7 +50,7 @@ class _LibraryScreenState extends State<LibraryScreen> {
   void _openHistory() {
     Navigator.push(
       context,
-      MaterialPageRoute(builder: (_) => const HistoryScreen()),
+      MaterialPageRoute(builder: (_) => HistoryScreen()),
     );
   }
 

--- a/lib/screens/main_menu.dart
+++ b/lib/screens/main_menu.dart
@@ -55,7 +55,7 @@ class MainMenu extends StatelessWidget {
                 ElevatedButton(
                   onPressed: () => Navigator.push(
                     context,
-                    MaterialPageRoute(builder: (_) => const HistoryScreen()),
+                    MaterialPageRoute(builder: (_) => HistoryScreen()),
                   ),
                   child: Text(AppLocalizations.of(context)!.history),
                 ),


### PR DESCRIPTION
## Summary
- Remove `const` before `HistoryScreen()` in library and main menu screens

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6890c3c567888326b7b98975484e0e52