### PR TITLE
Use positional parameter for pageLoadFailed localization

### DIFF
--- a/lib/screens/reader_screen.dart
+++ b/lib/screens/reader_screen.dart
@@ -132,7 +132,7 @@ class _ReaderScreenState extends State<ReaderScreen> {
         ScaffoldMessenger.of(context).showSnackBar(
           SnackBar(
             content: Text(
-              AppLocalizations.of(context)!.pageLoadFailed(page: pageNumber),
+              AppLocalizations.of(context)!.pageLoadFailed(pageNumber),
             ),
           ),
         );


### PR DESCRIPTION
## Summary
- fix reader screen to call `pageLoadFailed` using positional argument

## Testing
- `flutter gen-l10n` *(fails: command not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6890c887a0d0832682e1f13523a2e731