### PR TITLE
fix: add missing imports and adjust tests

### DIFF
--- a/test/archive_importer_test.dart
+++ b/test/archive_importer_test.dart
@@ -11,6 +11,7 @@ import 'package:path/path.dart' as p;
 import 'package:path_provider_platform_interface/path_provider_platform_interface.dart';
 import 'package:archive/archive.dart';
 import 'package:pdf_render/pdf_render.dart';
+import 'package:pdf_render_platform_interface/pdf_render_platform_interface.dart';
 
 import 'package:mana_reader/importers/rar_importer.dart';
 import 'package:mana_reader/importers/seven_zip_importer.dart';

--- a/test/importer_test.dart
+++ b/test/importer_test.dart
@@ -1,6 +1,7 @@
 import 'dart:convert';
 import 'dart:io';
 
+import 'package:flutter/services.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:path/path.dart' as p;
 import 'package:path_provider_platform_interface/path_provider_platform_interface.dart';
@@ -13,6 +14,7 @@ import 'package:mana_reader/importers/rar_importer.dart';
 import 'package:mana_reader/importers/seven_zip_importer.dart';
 import 'package:mana_reader/importers/pdf_importer.dart';
 import 'package:pdf_render/pdf_render.dart';
+import 'package:pdf_render_platform_interface/pdf_render_platform_interface.dart';
 import 'dart:typed_data';
 import 'dart:ffi';
 import 'dart:ui' as ui;
@@ -223,8 +225,7 @@ void main() {
     test('SevenZipImporter extracts images', () async {
       final sevenScript = File('/usr/local/bin/7z');
       if (!sevenScript.existsSync()) {
-        sevenScript
-          ..writeAsStringSync('''#!/usr/bin/env python3
+        sevenScript.writeAsStringSync('''#!/usr/bin/env python3
 import sys, zipfile, os
 args=sys.argv[1:]
 archive=args[1]
@@ -232,8 +233,8 @@ dest=args[2]
 if dest.startswith("-o"):
     dest=dest[2:]
 zipfile.ZipFile(archive).extractall(dest)
-''')
-          ..chmodSync(0x1ED);
+''');
+        await Process.run('chmod', ['755', sevenScript.path]);
       }
 
       final tmp = Directory.systemTemp.createTempSync();
@@ -254,8 +255,7 @@ zipfile.ZipFile(archive).extractall(dest)
     test('SevenZipImporter extracts images from .7z files', () async {
       final sevenScript = File('/usr/local/bin/7z');
       if (!sevenScript.existsSync()) {
-        sevenScript
-          ..writeAsStringSync('''#!/usr/bin/env python3
+        sevenScript.writeAsStringSync('''#!/usr/bin/env python3
 import sys, zipfile, os
 args=sys.argv[1:]
 archive=args[1]
@@ -263,8 +263,8 @@ dest=args[2]
 if dest.startswith("-o"):
     dest=dest[2:]
 zipfile.ZipFile(archive).extractall(dest)
-''')
-          ..chmodSync(0x1ED);
+''');
+        await Process.run('chmod', ['755', sevenScript.path]);
       }
 
       final tmp = Directory.systemTemp.createTempSync();

--- a/test/sync_service_test.dart
+++ b/test/sync_service_test.dart
@@ -7,11 +7,13 @@ import 'dart:ui' as ui;
 
 import 'package:flutter/services.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:mana_reader/importers/seven_zip_importer.dart';
 import 'package:path/path.dart' as p;
 import 'package:path_provider_platform_interface/path_provider_platform_interface.dart';
 import 'package:sqflite_common_ffi/sqflite_ffi.dart';
 import 'package:archive/archive.dart';
 import 'package:pdf_render/pdf_render.dart';
+import 'package:pdf_render_platform_interface/pdf_render_platform_interface.dart';
 
 import 'package:mana_reader/import/sync_service.dart';
 import 'package:mana_reader/database/db_helper.dart';


### PR DESCRIPTION
## Summary
- ensure tests import Flutter services, SevenZipImporter, and pdf_render platform interface
- replace chmodSync usages with Process.run

## Testing
- `flutter test` *(fails: command not found)*
- `dart test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6890cad77e348326b3a72517fd49adff