### PR TITLE
docs: document mobile-only support

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,12 +1,12 @@
 # Mana Reader
 
-Mana Reader aims to be a lightweight, cross‑platform manga and doujinshi reader built with Flutter. The project provides a simple foundation for organizing and viewing local comic archives.
+Mana Reader aims to be a lightweight, mobile manga and doujinshi reader built with Flutter. Currently the app supports only Android and iOS. The desktop platform folders (Linux, macOS and Windows) have been removed for now but will be reintroduced later.
 
 ## Current Features
 
 - **SQLite library**: stores imported books with title, language, tags and last read page.
 - **Library screen**: shows all imported books in a grid layout.
-- **Cross‑platform boilerplate**: Android project files are present and stubs exist for iOS, Linux, macOS and Windows.
+- **Mobile boilerplate**: Android and iOS project files are present. Desktop platform folders will return once support for them is reintroduced.
 
 ## Requirements
 
@@ -25,11 +25,7 @@ Mana Reader aims to be a lightweight, cross‑platform manga and doujinshi reade
 
 ## Running
 
-From the repository root run `flutter run` and select the desired target device.
-
-- **Android**: ensure an emulator or physical device is available.
-- **iOS / macOS**: project folders are included but contain only placeholders. Platform support will be added later.
-- **Linux / Windows**: similarly include placeholder folders for future desktop support.
+From the repository root run `flutter run` and select an Android emulator, physical device or an iOS simulator/connected device. Desktop platforms are currently unsupported and their folders have been removed; they will be reintroduced in a future release.
 
 Icon images have been removed from version control. During development you can generate them with `flutter create --platforms=<platform>` or tools like `flutter_launcher_icons`. Large binary assets should be stored using Git LFS, which is configured for common image formats in this repository.
 
@@ -39,9 +35,11 @@ Platform icon files are not stored in this repository. Generate them locally wit
 
 ## Platform Setup
 
-These folders contain only minimal stubs. Generate the full project files with
-`flutter create --platforms=<platform> .` if they are missing before adjusting
-identifiers or signing settings.
+Only Android and iOS project files are tracked in this repository. If you need to
+regenerate them, run `flutter create --platforms=android,ios .` before adjusting
+identifiers or signing settings. Desktop platform folders have been removed but
+will be reintroduced later; when support returns, they can be recreated with
+`flutter create --platforms=linux,macos,windows .`.
 
 ### iOS
 
@@ -54,38 +52,6 @@ identifiers or signing settings.
 ```bash
 flutter build ios     # debug or profile
 flutter build ipa     # release archive
-```
-
-### macOS
-
-- Generate the macOS folder if needed and open `macos/Runner.xcodeproj`.
-- Change **PRODUCT_BUNDLE_IDENTIFIER** and signing options in Xcode.
-- Build with:
-
-```bash
-flutter build macos
-```
-
-### Linux
-
-- The bundle identifier for Linux is defined as the binary name in
-  `linux/CMakeLists.txt`.
-- After editing, build the desktop binary with:
-
-```bash
-flutter build linux
-```
-
-### Windows
-
-- If the Windows folder is not present, run `flutter create --platforms=windows .`.
-- Edit `windows/runner/CMakeLists.txt` and `windows/runner/Runner.rc` to adjust
-  the executable name and company info.
-- Optional code signing can be performed using `signtool` after building.
-- Build with:
-
-```bash
-flutter build windows
 ```
 
 ## Roadmap


### PR DESCRIPTION
## Summary
- note the app currently supports only Android and iOS
- mention that desktop platform folders were removed but will return later

## Testing
- `flutter analyze` *(fails: command not found)*
- `apt-get install -y flutter` *(fails: Unable to locate package flutter)*
- `flutter test` *(fails: command not found)*
- `dart test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6890ec3df9a48326b447b10e84bc3b42