### PR TITLE
ci: disable desktop platforms

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,6 +12,7 @@ jobs:
         with:
           channel: stable
           cache: true
+      - run: flutter config --no-enable-linux-desktop --no-enable-macos-desktop --no-enable-windows-desktop
       - run: flutter pub get
       - run: dart format --set-exit-if-changed .
       - run: flutter analyze


### PR DESCRIPTION
## Summary
- disable linux/macos/windows desktop platforms in CI to focus on Android/iOS

## Testing
- `flutter config --no-enable-linux-desktop --no-enable-macos-desktop --no-enable-windows-desktop`
- `flutter pub get`
- `dart format --output=none --set-exit-if-changed .`
- `flutter analyze` *(fails: undefined identifiers and missing files)*
- `flutter test` *(fails: missing package pdf_render_platform_interface)*

------
https://chatgpt.com/codex/tasks/task_e_6890ec4f74e883269f9cef2414687e72