### PR TITLE
Add Internet permission to Android manifest

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -1,4 +1,5 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android">
+    <uses-permission android:name="android.permission.INTERNET" />
     <application
         android:label="mana_reader"
         android:icon="@mipmap/ic_launcher">


### PR DESCRIPTION
## Summary
- allow app to access the network by requesting `INTERNET` permission

## Testing
- `flutter test` *(fails: path is pinned to version 1.9.0 by flutter_test from the flutter SDK)*
- `flutter build apk` *(fails: Build failed due to use of deleted Android v1 embedding)*

------
https://chatgpt.com/codex/tasks/task_e_6890f3c6402883268650b861a8f98829