### PR TITLE
Add database close method and lifecycle cleanup

### DIFF
--- a/lib/database/db_helper.dart
+++ b/lib/database/db_helper.dart
@@ -342,4 +342,10 @@ class DbHelper {
     );
     return maps.map((e) => e['page'] as int).toList();
   }
+
+  /// Closes the underlying database and resets the instance.
+  Future<void> close() async {
+    await _db?.close();
+    _db = null;
+  }
 }

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -2,11 +2,23 @@ import 'package:flutter/material.dart';
 import 'screens/main_menu.dart';
 import 'package:flutter_localizations/flutter_localizations.dart';
 import 'l10n/app_localizations.dart';
+import 'database/db_helper.dart';
 
 void main() => runApp(const ManaReaderApp());
 
-class ManaReaderApp extends StatelessWidget {
+class ManaReaderApp extends StatefulWidget {
   const ManaReaderApp({super.key});
+
+  @override
+  State<ManaReaderApp> createState() => _ManaReaderAppState();
+}
+
+class _ManaReaderAppState extends State<ManaReaderApp> {
+  @override
+  void dispose() {
+    DbHelper.instance.close();
+    super.dispose();
+  }
 
   @override
   Widget build(BuildContext context) {


### PR DESCRIPTION
## Summary
- add `DbHelper.close` for closing and resetting the SQLite database
- close database during app disposal for clean shutdown

## Testing
- `flutter test` *(fails: command not found)*


------
https://chatgpt.com/codex/tasks/task_e_6890f771362c83269baeb163cc155441