### PR TITLE
Configure Android build for Java 17

### DIFF
--- a/android/app/build.gradle.kts
+++ b/android/app/build.gradle.kts
@@ -21,6 +21,14 @@ android {
             signingConfig = signingConfigs.getByName("debug")
         }
     }
+
+    compileOptions {
+        sourceCompatibility = JavaVersion.VERSION_17
+        targetCompatibility = JavaVersion.VERSION_17
+    }
+    kotlinOptions {
+        jvmTarget = "17"
+    }
 }
 
 flutter {


### PR DESCRIPTION
## Summary
- target Android module to Java 17 by adding compileOptions and kotlinOptions

## Testing
- `gradle -p android help`
- `flutter test` *(fails: command not found)*
- `dart test` *(fails: command not found)*
- `apt-get install -y dart` *(fails: Unable to locate package dart)*
- `apt-get install -y flutter` *(fails: Unable to locate package flutter)*

------
https://chatgpt.com/codex/tasks/task_e_6890f8fe33748326bec552feed79ba5d