### PR TITLE
Handle directory listing errors in reader screen

### DIFF
--- a/lib/screens/reader_screen.dart
+++ b/lib/screens/reader_screen.dart
@@ -142,11 +142,24 @@ class _ReaderScreenState extends State<ReaderScreen> {
 
   Future<void> _loadPages() async {
     final dir = Directory(_book.path);
-    final pages = await dir
-        .list(recursive: true)
-        .where((e) => e is File && _isImage(e.path))
-        .map((e) => e.path)
-        .toList();
+    late final List<String> pages;
+    try {
+      pages = await dir
+          .list(recursive: true)
+          .where((e) => e is File && _isImage(e.path))
+          .map((e) => e.path)
+          .toList();
+    } catch (e, st) {
+      debugPrint('Failed to read pages from ${_book.path}: $e');
+      debugPrintStack(stackTrace: st);
+      if (!mounted) return;
+      ScaffoldMessenger.of(context).showSnackBar(
+        const SnackBar(
+          content: Text('Failed to load pages'),
+        ),
+      );
+      return;
+    }
     pages.sort();
     if (!mounted) return;
     setState(() {


### PR DESCRIPTION
## Summary
- wrap page loading in try/catch to handle file system errors
- show SnackBar on failure to list book pages

## Testing
- `flutter test` *(fails: command not found)*
- `apt-get install -y flutter` *(fails: unable to locate package)*

------
https://chatgpt.com/codex/tasks/task_e_6890faac265c83268f04bceba4e96e58