### PR TITLE
Add dummy sample book for testing

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,10 @@ From the repository root run `flutter run` and select an Android emulator, physi
 
 Icon images have been removed from version control. During development you can generate them with `flutter create --platforms=<platform>` or tools like `flutter_launcher_icons`. Large binary assets should be stored using Git LFS, which is configured for common image formats in this repository.
 
+## Sample Book
+
+A small three-page dummy book is available at `assets/sample_books/dummy_story.pdf`. Use the app's import feature to load it and verify reading and library management behaviour.
+
 ## Platform Icons
 
 Platform icon files are not stored in this repository. Generate them locally with `flutter create .` or copy your own icons into the platform asset folders before building. If you wish to keep custom icons under version control, add them via Git LFS so only optimized binaries are tracked.

--- a/assets/sample_books/dummy_story.pdf
+++ b/assets/sample_books/dummy_story.pdf
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:f826dcbf1fb0bc6dc55feac6df8c4c5beeaedfd1a37a1b812574a90539575a58
+size 2012


### PR DESCRIPTION
## Summary
- add a three-page dummy PDF story under `assets/sample_books/dummy_story.pdf`
- document the sample book in the README so it can be imported for manual testing

## Testing
- `flutter test` *(fails: command not found)*
- `apt-get install -y flutter` *(fails: Unable to locate package)*

------
https://chatgpt.com/codex/tasks/task_e_6891092a766c83269317765dd52dc688