### PR TITLE
Fix PDF importer and pdf_render tests

### DIFF
--- a/lib/importers/pdf_importer.dart
+++ b/lib/importers/pdf_importer.dart
@@ -26,6 +26,7 @@ class PdfImporter extends Importer {
       final file = File(imagePath);
       await file.writeAsBytes(bytes);
       pages.add(imagePath);
+      img.dispose();
     }
     await doc.dispose();
     return BookModel(

--- a/test/archive_importer_test.dart
+++ b/test/archive_importer_test.dart
@@ -11,7 +11,7 @@ import 'package:path/path.dart' as p;
 import 'package:path_provider_platform_interface/path_provider_platform_interface.dart';
 import 'package:archive/archive.dart';
 import 'package:pdf_render/pdf_render.dart';
-import 'package:pdf_render_platform_interface/pdf_render_platform_interface.dart';
+import 'package:pdf_render/src/interfaces/pdf_render_platform_interface.dart';
 
 import 'package:mana_reader/importers/rar_importer.dart';
 import 'package:mana_reader/importers/seven_zip_importer.dart';

--- a/test/importer_test.dart
+++ b/test/importer_test.dart
@@ -14,7 +14,7 @@ import 'package:mana_reader/importers/rar_importer.dart';
 import 'package:mana_reader/importers/seven_zip_importer.dart';
 import 'package:mana_reader/importers/pdf_importer.dart';
 import 'package:pdf_render/pdf_render.dart';
-import 'package:pdf_render_platform_interface/pdf_render_platform_interface.dart';
+import 'package:pdf_render/src/interfaces/pdf_render_platform_interface.dart';
 import 'dart:typed_data';
 import 'dart:ffi';
 import 'dart:ui' as ui;

--- a/test/sync_service_test.dart
+++ b/test/sync_service_test.dart
@@ -13,7 +13,7 @@ import 'package:path_provider_platform_interface/path_provider_platform_interfac
 import 'package:sqflite_common_ffi/sqflite_ffi.dart';
 import 'package:archive/archive.dart';
 import 'package:pdf_render/pdf_render.dart';
-import 'package:pdf_render_platform_interface/pdf_render_platform_interface.dart';
+import 'package:pdf_render/src/interfaces/pdf_render_platform_interface.dart';
 
 import 'package:mana_reader/import/sync_service.dart';
 import 'package:mana_reader/database/db_helper.dart';


### PR DESCRIPTION
## Summary
- dispose rendered PDF images to release resources
- update tests to import pdf_render internal platform interface

## Testing
- `dart analyze lib/importers/pdf_importer.dart`
- `flutter test test/importer_test.dart` *(fails: Unsupported archive type)*

------
https://chatgpt.com/codex/tasks/task_e_68916e359964832681064e658e4389d7