### PR TITLE
Close PDF pages after rendering images

### DIFF
--- a/lib/importers/pdf_importer.dart
+++ b/lib/importers/pdf_importer.dart
@@ -22,10 +22,12 @@ class PdfImporter extends Importer {
       final ui.Image image = await img.createImageIfNotAvailable();
       final bytes =
           (await image.toByteData(format: ui.ImageByteFormat.png))!.buffer.asUint8List();
+      image.dispose();
       final imagePath = p.join(destDir.path, '${i.toString().padLeft(4, '0')}.png');
       final file = File(imagePath);
       await file.writeAsBytes(bytes);
       pages.add(imagePath);
+      await page.close();
       img.dispose();
     }
     await doc.dispose();


### PR DESCRIPTION
## Summary
- Ensure PDF pages are properly closed after rendering
- Dispose intermediate PDF images to free resources

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68920b85253c83269e933bc632477ba6