### PR TITLE
Use Object for equality overrides in tests

### DIFF
--- a/test/archive_importer_test.dart
+++ b/test/archive_importer_test.dart
@@ -50,7 +50,7 @@ class _FakePdfDocument extends PdfDocument {
   Future<PdfPage> getPage(int pageNumber) async => _FakePdfPage(this, pageNumber);
 
   @override
-  bool operator ==(dynamic other) => identical(this, other);
+  bool operator ==(Object other) => identical(this, other);
 
   @override
   int get hashCode => super.hashCode;

--- a/test/importer_test.dart
+++ b/test/importer_test.dart
@@ -57,7 +57,7 @@ class _FakePdfDocument extends PdfDocument {
       _FakePdfPage(this, pageNumber);
 
   @override
-  bool operator ==(dynamic other) => identical(this, other);
+  bool operator ==(Object other) => identical(this, other);
 
   @override
   int get hashCode => super.hashCode;

--- a/test/sync_service_test.dart
+++ b/test/sync_service_test.dart
@@ -51,7 +51,7 @@ class _FakePdfDocument extends PdfDocument {
   Future<PdfPage> getPage(int pageNumber) async => _FakePdfPage(this, pageNumber);
 
   @override
-  bool operator ==(dynamic other) => identical(this, other);
+  bool operator ==(Object other) => identical(this, other);
 
   @override
   int get hashCode => super.hashCode;


### PR DESCRIPTION
## Summary
- Use `Object` parameter for `==` overrides in `_FakePdfDocument` test doubles.
- Keep `hashCode` overrides aligned with identity-based equality.

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68924926bdd08326b724d8680eb521d5