### PR TITLE
chore: update mock method channel handling

### DIFF
--- a/test/archive_importer_test.dart
+++ b/test/archive_importer_test.dart
@@ -28,26 +28,30 @@ class _FakePdfRenderPlatform extends PdfRenderPlatform {
   Future<PdfDocument?> openData(Uint8List data) async => _FakePdfDocument();
 
   @override
-  Future<PdfPageImageTexture> createTexture({required PdfDocument pdfDocument, required int pageNumber}) =>
-      throw UnimplementedError();
+  Future<PdfPageImageTexture> createTexture({
+    required PdfDocument pdfDocument,
+    required int pageNumber,
+  }) => throw UnimplementedError();
 }
 
 class _FakePdfDocument extends PdfDocument {
   _FakePdfDocument()
-      : super(
-            sourceName: 'fake.pdf',
-            pageCount: 1,
-            verMajor: 1,
-            verMinor: 7,
-            isEncrypted: false,
-            allowsCopying: true,
-            allowsPrinting: true);
+    : super(
+        sourceName: 'fake.pdf',
+        pageCount: 1,
+        verMajor: 1,
+        verMinor: 7,
+        isEncrypted: false,
+        allowsCopying: true,
+        allowsPrinting: true,
+      );
 
   @override
   Future<void> dispose() async {}
 
   @override
-  Future<PdfPage> getPage(int pageNumber) async => _FakePdfPage(this, pageNumber);
+  Future<PdfPage> getPage(int pageNumber) async =>
+      _FakePdfPage(this, pageNumber);
 
   @override
   bool operator ==(Object other) => identical(this, other);
@@ -58,7 +62,7 @@ class _FakePdfDocument extends PdfDocument {
 
 class _FakePdfPage extends PdfPage {
   _FakePdfPage(PdfDocument doc, int num)
-      : super(document: doc, pageNumber: num, width: 1, height: 1);
+    : super(document: doc, pageNumber: num, width: 1, height: 1);
 
   @override
   Future<PdfPageImage> render({
@@ -78,17 +82,18 @@ class _FakePdfPage extends PdfPage {
 
 class _FakePdfPageImage extends PdfPageImage {
   _FakePdfPageImage(int page)
-      : _pixels = Uint8List.fromList(const [255, 0, 0, 255]),
-        super(
-            pageNumber: page,
-            x: 0,
-            y: 0,
-            width: 1,
-            height: 1,
-            fullWidth: 1,
-            fullHeight: 1,
-            pageWidth: 1,
-            pageHeight: 1);
+    : _pixels = Uint8List.fromList(const [255, 0, 0, 255]),
+      super(
+        pageNumber: page,
+        x: 0,
+        y: 0,
+        width: 1,
+        height: 1,
+        fullWidth: 1,
+        fullHeight: 1,
+        pageWidth: 1,
+        pageHeight: 1,
+      );
 
   final Uint8List _pixels;
   ui.Image? _image;
@@ -109,22 +114,30 @@ class _FakePdfPageImage extends PdfPageImage {
   Future<ui.Image> createImageIfNotAvailable() async {
     if (_image != null) return _image!;
     final comp = Completer<ui.Image>();
-    ui.decodeImageFromPixels(_pixels, 1, 1, ui.PixelFormat.rgba8888, (img) => comp.complete(img));
+    ui.decodeImageFromPixels(
+      _pixels,
+      1,
+      1,
+      ui.PixelFormat.rgba8888,
+      (img) => comp.complete(img),
+    );
     _image = await comp.future;
     return _image!;
   }
 
   @override
-  Future<ui.Image> createImageDetached() async => await createImageIfNotAvailable();
+  Future<ui.Image> createImageDetached() async =>
+      await createImageIfNotAvailable();
 }
 
 class _FakePathProviderPlatform extends PathProviderPlatform {
-  final Directory tempDir = Directory.systemTemp.createTempSync('mana_reader_test');
+  final Directory tempDir = Directory.systemTemp.createTempSync(
+    'mana_reader_test',
+  );
 
   @override
   Future<String?> getApplicationDocumentsPath() async => tempDir.path;
 }
-
 
 void main() {
   TestWidgetsFlutterBinding.ensureInitialized();
@@ -133,24 +146,30 @@ void main() {
   group('Archive importers', () {
     test('RarImporter extracts images from archive', () async {
       const channel = MethodChannel('com.lkrjangid.rar');
-      channel.setMockMethodCallHandler((call) async {
-        if (call.method == 'extractRarFile') {
-          final bytes = File(call.arguments['rarFilePath'] as String).readAsBytesSync();
-          final archive = ZipDecoder().decodeBytes(bytes);
-          final dest = call.arguments['destinationPath'] as String;
-          for (final f in archive) {
-            if (f.isFile) {
-              final out = File(p.join(dest, f.name))..createSync(recursive: true);
-              out.writeAsBytesSync(f.content as List<int>);
+      TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+          .setMockMethodCallHandler(channel, (call) async {
+            if (call.method == 'extractRarFile') {
+              final bytes = File(
+                call.arguments['rarFilePath'] as String,
+              ).readAsBytesSync();
+              final archive = ZipDecoder().decodeBytes(bytes);
+              final dest = call.arguments['destinationPath'] as String;
+              for (final f in archive) {
+                if (f.isFile) {
+                  final out = File(p.join(dest, f.name))
+                    ..createSync(recursive: true);
+                  out.writeAsBytesSync(f.content as List<int>);
+                }
+              }
+              return {'success': true, 'message': 'ok'};
             }
-          }
-          return {'success': true, 'message': 'ok'};
-        }
-        return null;
-      });
+            return null;
+          });
 
       final tmp = Directory.systemTemp.createTempSync();
-      final img = base64Decode('iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAA C0lEQVR42mP8Xw8AAiMB7g6lbYkAAAAASUVORK5CYII=');
+      final img = base64Decode(
+        'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAA C0lEQVR42mP8Xw8AAiMB7g6lbYkAAAAASUVORK5CYII=',
+      );
       final archive = Archive()..addFile(ArchiveFile('a.png', img.length, img));
       final bytes = ZipEncoder().encode(archive)!;
       final rarPath = p.join(tmp.path, 't.cbr');
@@ -177,7 +196,8 @@ void main() {
           final archive = ZipDecoder().decodeBytes(bytes);
           for (final f in archive) {
             if (f.isFile) {
-              final out = File(p.join(destArg, f.name))..createSync(recursive: true);
+              final out = File(p.join(destArg, f.name))
+                ..createSync(recursive: true);
               out.writeAsBytesSync(f.content as List<int>);
             }
           }
@@ -187,7 +207,9 @@ void main() {
       };
 
       final tmp = Directory.systemTemp.createTempSync();
-      final img = base64Decode('iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAA C0lEQVR42mP8Xw8AAiMB7g6lbYkAAAAASUVORK5CYII=');
+      final img = base64Decode(
+        'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAA C0lEQVR42mP8Xw8AAiMB7g6lbYkAAAAASUVORK5CYII=',
+      );
       final archive = Archive()..addFile(ArchiveFile('b.png', img.length, img));
       final bytes = ZipEncoder().encode(archive)!;
       final sevenPath = p.join(tmp.path, 't.cb7');
@@ -199,48 +221,56 @@ void main() {
       expect(File(book.pages.first).existsSync(), isTrue);
     });
 
-    test('SevenZipImporter extracts images from .7z using mocked Process.run',
-        () async {
-      processRun = (String exe, List<String> args) async {
-        if (exe == 'which' || exe == 'where') {
-          return ProcessResult(0, 0, '', '');
-        }
-        if (exe == '7z') {
-          final archivePath = args[1];
-          var destArg = args[2];
-          if (destArg.startsWith('-o')) {
-            destArg = destArg.substring(2);
+    test(
+      'SevenZipImporter extracts images from .7z using mocked Process.run',
+      () async {
+        processRun = (String exe, List<String> args) async {
+          if (exe == 'which' || exe == 'where') {
+            return ProcessResult(0, 0, '', '');
           }
-          final bytes = File(archivePath).readAsBytesSync();
-          final archive = ZipDecoder().decodeBytes(bytes);
-          for (final f in archive) {
-            if (f.isFile) {
-              final out = File(p.join(destArg, f.name))..createSync(recursive: true);
-              out.writeAsBytesSync(f.content as List<int>);
+          if (exe == '7z') {
+            final archivePath = args[1];
+            var destArg = args[2];
+            if (destArg.startsWith('-o')) {
+              destArg = destArg.substring(2);
             }
+            final bytes = File(archivePath).readAsBytesSync();
+            final archive = ZipDecoder().decodeBytes(bytes);
+            for (final f in archive) {
+              if (f.isFile) {
+                final out = File(p.join(destArg, f.name))
+                  ..createSync(recursive: true);
+                out.writeAsBytesSync(f.content as List<int>);
+              }
+            }
+            return ProcessResult(0, 0, '', '');
           }
-          return ProcessResult(0, 0, '', '');
-        }
-        throw UnsupportedError(exe);
-      };
+          throw UnsupportedError(exe);
+        };
 
-      final tmp = Directory.systemTemp.createTempSync();
-      final img = base64Decode('iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAA C0lEQVR42mP8Xw8AAiMB7g6lbYkAAAAASUVORK5CYII=');
-      final archive = Archive()..addFile(ArchiveFile('c.png', img.length, img));
-      final bytes = ZipEncoder().encode(archive)!;
-      final sevenPath = p.join(tmp.path, 't.7z');
-      File(sevenPath).writeAsBytesSync(bytes);
+        final tmp = Directory.systemTemp.createTempSync();
+        final img = base64Decode(
+          'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAA C0lEQVR42mP8Xw8AAiMB7g6lbYkAAAAASUVORK5CYII=',
+        );
+        final archive = Archive()
+          ..addFile(ArchiveFile('c.png', img.length, img));
+        final bytes = ZipEncoder().encode(archive)!;
+        final sevenPath = p.join(tmp.path, 't.7z');
+        File(sevenPath).writeAsBytesSync(bytes);
 
-      final importer = SevenZipImporter();
-      final book = await importer.import(sevenPath);
-      expect(book.pages.length, 1);
-      expect(File(book.pages.first).existsSync(), isTrue);
-    });
+        final importer = SevenZipImporter();
+        final book = await importer.import(sevenPath);
+        expect(book.pages.length, 1);
+        expect(File(book.pages.first).existsSync(), isTrue);
+      },
+    );
 
     test('PdfImporter renders pages from small PDF', () async {
       PdfRenderPlatform.instance = _FakePdfRenderPlatform();
       final tmp = Directory.systemTemp.createTempSync();
-      final pdfData = base64Decode('JVBERi0xLjEKMSAwIG9iajw8L1R5cGUvQ2F0YWxvZy9QYWdlcyAyIDAgUj4+ZW5kb2JqCjIgMCBvYmo8PC9UeXBlL1BhZ2VzL0tpZHNbMyAwIFJdL0NvdW50IDE+PmVuZG9iagozIDAgb2JqPDwvVHlwZS9QYWdlL1BhcmVudCAyIDAgUi9NZWRpYUJveFswIDAgNjEyIDc5Ml0+PmVuZG9iagp0cmFpbGVyPDwvUm9vdCAxIDAgUi9TaXplIDQ+PgolJUVPRg==');
+      final pdfData = base64Decode(
+        'JVBERi0xLjEKMSAwIG9iajw8L1R5cGUvQ2F0YWxvZy9QYWdlcyAyIDAgUj4+ZW5kb2JqCjIgMCBvYmo8PC9UeXBlL1BhZ2VzL0tpZHNbMyAwIFJdL0NvdW50IDE+PmVuZG9iagozIDAgb2JqPDwvVHlwZS9QYWdlL1BhcmVudCAyIDAgUi9NZWRpYUJveFswIDAgNjEyIDc5Ml0+PmVuZG9iagp0cmFpbGVyPDwvUm9vdCAxIDAgUi9TaXplIDQ+PgolJUVPRg==',
+      );
       final pdfPath = p.join(tmp.path, 'a.pdf');
       File(pdfPath).writeAsBytesSync(pdfData);
 
@@ -251,4 +281,3 @@ void main() {
     });
   });
 }
-

--- a/test/importer_test.dart
+++ b/test/importer_test.dart
@@ -187,24 +187,25 @@ void main() {
 
     test('RarImporter extracts images', () async {
       const channel = MethodChannel('com.lkrjangid.rar');
-      channel.setMockMethodCallHandler((call) async {
-        if (call.method == 'extractRarFile') {
-          final bytes = File(
-            call.arguments['rarFilePath'] as String,
-          ).readAsBytesSync();
-          final archive = ZipDecoder().decodeBytes(bytes);
-          final dest = call.arguments['destinationPath'] as String;
-          for (final f in archive) {
-            if (f.isFile) {
-              final out = File(p.join(dest, f.name))
-                ..createSync(recursive: true);
-              out.writeAsBytesSync(f.content as List<int>);
+      TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+          .setMockMethodCallHandler(channel, (call) async {
+            if (call.method == 'extractRarFile') {
+              final bytes = File(
+                call.arguments['rarFilePath'] as String,
+              ).readAsBytesSync();
+              final archive = ZipDecoder().decodeBytes(bytes);
+              final dest = call.arguments['destinationPath'] as String;
+              for (final f in archive) {
+                if (f.isFile) {
+                  final out = File(p.join(dest, f.name))
+                    ..createSync(recursive: true);
+                  out.writeAsBytesSync(f.content as List<int>);
+                }
+              }
+              return {'success': true, 'message': 'ok'};
             }
-          }
-          return {'success': true, 'message': 'ok'};
-        }
-        return null;
-      });
+            return null;
+          });
 
       final tmp = Directory.systemTemp.createTempSync();
       final img = base64Decode(


### PR DESCRIPTION
## Summary
- update `setMockMethodCallHandler` usages in tests to follow latest Flutter `defaultBinaryMessenger`

## Testing
- `dart format test/archive_importer_test.dart test/importer_test.dart`
- `dart analyze` *(fails: Target of URI doesn't exist: 'package:flutter/material.dart')*
- `dart test` *(fails: Flutter SDK is not available)*

------
https://chatgpt.com/codex/tasks/task_e_68924fb7a2f08326983af4a01c780a4b