### PR TITLE
Restrict file_picker plugin to mobile platforms

### DIFF
--- a/pubspec.lock
+++ b/pubspec.lock
@@ -77,10 +77,10 @@ packages:
     dependency: "direct main"
     description:
       name: file_picker
-      sha256: "1bbf65dd997458a08b531042ec3794112a6c39c07c37ff22113d2e7e4f81d4e4"
+      sha256: f9245fc33aeba9e0b938d7f3785f10b7a7230e05b8fc40f5a6a8342d7899e391
       url: "https://pub.dev"
     source: hosted
-    version: "6.2.1"
+    version: "3.0.4"
   flutter:
     dependency: "direct main"
     description: flutter
@@ -490,14 +490,6 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.1.1"
-  win32:
-    dependency: transitive
-    description:
-      name: win32
-      sha256: "66814138c3562338d05613a6e368ed8cfb237ad6d64a9e9334be3f309acfca03"
-      url: "https://pub.dev"
-    source: hosted
-    version: "5.14.0"
   xdg_directories:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -16,7 +16,7 @@ dependencies:
   path: 1.9.1
 
   http: ^0.13.6
-  file_picker: ^6.2.1
+  file_picker: 3.0.4
   archive: ^3.3.7
   rar: ^0.1.0
   pdf_render: ^1.4.12


### PR DESCRIPTION
## Summary
- limit file_picker dependency to mobile-only version to avoid desktop plugin warnings

## Testing
- `flutter pub get`
- `flutter test` *(fails: MissingPluginException in reader and importer tests, Bad state: databaseFactory not initialized)*

------
https://chatgpt.com/codex/tasks/task_e_689266fa3fcc83269cd98e4cf2db51a7