### PR TITLE
Guard ZIP imports against path traversal

### DIFF
--- a/lib/importers/zip_importer.dart
+++ b/lib/importers/zip_importer.dart
@@ -14,10 +14,15 @@ class ZipImporter extends Importer {
     final archive = ZipDecoder().decodeBytes(bytes);
     final baseName = p.basenameWithoutExtension(filePath);
     final destDir = await _createDestDir(baseName);
+    final destPath = p.normalize(destDir.path);
     final pages = <String>[];
     for (final file in archive) {
       if (file.isFile) {
-        final outPath = p.join(destDir.path, file.name);
+        final outPath = p.normalize(p.join(destPath, file.name));
+        if (!p.isWithin(destPath, outPath)) {
+          // Skip files that would escape the destination directory.
+          continue;
+        }
         File(outPath)
           ..createSync(recursive: true)
           ..writeAsBytesSync(file.content as List<int>);


### PR DESCRIPTION
## Summary
- normalize ZIP entry paths and skip files that resolve outside the destination folder
- add regression test ensuring `../` entries are ignored

## Testing
- `flutter test test/importer_test.dart` *(fails: Unsupported archive type; MissingPluginException: No implementation found for method file on channel pdf_render)*

------
https://chatgpt.com/codex/tasks/task_e_6892bd23cb588326b99c7b9c351ed977