### PR TITLE
Generate JUnit test reports

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,11 +32,13 @@ jobs:
 
       - name: Install test formatter
         run: |
-          dart pub global activate junitreport
+          pub global activate junitreport
           echo "$HOME/.pub-cache/bin" >> $GITHUB_PATH
 
       - name: Run Flutter tests
-        run: flutter test --machine | tojunit --output junit.xml
+        run: |
+          mkdir -p build/test-results
+          flutter test --machine | tojunit --output build/test-results/flutter-junit.xml
 
       - name: Run Android unit tests
         run: ./gradlew testDebugUnitTest
@@ -54,7 +56,7 @@ jobs:
         uses: actions/upload-artifact@v3
         with:
           name: flutter-tests
-          path: junit.xml
+          path: build/test-results/flutter-junit.xml
 
       - name: Upload Android test results
         uses: actions/upload-artifact@v3

--- a/README.md
+++ b/README.md
@@ -80,8 +80,12 @@ To run the analyzer and test suite locally:
 
 ```bash
 flutter analyze
-flutter test
+./tool/test.sh
 ```
+
+The test script generates `build/test-results/flutter-junit.xml` for reporting.
+Install the converter with `dart pub global activate junitreport` if `tojunit` is
+not already available in your PATH.
 
 Make sure you have the Flutter SDK installed and dependencies fetched with `flutter pub get`.
 

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -9,6 +9,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "3.6.1"
+  args:
+    dependency: transitive
+    description:
+      name: args
+      sha256: "d0481093c50b1da8910eb0bb301626d4d8eb7284aa739614d2b394ee09e3ea04"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.7.0"
   async:
     dependency: transitive
     description:
@@ -149,6 +157,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "0.6.7"
+  junitreport:
+    dependency: "direct dev"
+    description:
+      name: junitreport
+      sha256: "139a457f5d91e82744df09d04f272d23b6a81c8ef9b8b3bd1cd2e1768460fbeb"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.0.2"
   leak_tracker:
     dependency: transitive
     description:
@@ -458,6 +474,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "0.7.4"
+  testreport:
+    dependency: transitive
+    description:
+      name: testreport
+      sha256: "d9b9af11e591d15724f63324b7957e6b36c04cca293147db7761064bbf363b0d"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.0.1"
   typed_data:
     dependency: transitive
     description:
@@ -498,6 +522,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.1.0"
+  xml:
+    dependency: transitive
+    description:
+      name: xml
+      sha256: "80d494c09849dc3f899d227a78c30c5b949b985ededf884cb3f3bcd39f4b447a"
+      url: "https://pub.dev"
+    source: hosted
+    version: "5.4.1"
 sdks:
   dart: ">=3.8.0 <4.0.0"
   flutter: ">=3.27.0"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -34,6 +34,7 @@ dev_dependencies:
   sqflite_common_ffi: ^2.3.0
   path_provider_platform_interface: any
   pdf_render_platform_interface: any
+  junitreport: ^2.0.2
 
 flutter:
   uses-material-design: true

--- a/tool/test.sh
+++ b/tool/test.sh
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+# Runs Flutter tests and outputs a JUnit XML report.
+set -e
+mkdir -p build/test-results
+flutter test --machine | tojunit --output build/test-results/flutter-junit.xml


### PR DESCRIPTION
## Summary
- add `junitreport` as dev dependency for JUnit conversion
- convert Flutter test output to `build/test-results/flutter-junit.xml` in CI
- document and script local test runs that produce a JUnit XML report

## Testing
- `./tool/test.sh` *(fails: `flutter: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_6893562896c48326a5e712a9922eaa9f