### PR TITLE
Add integration navigation test and CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,6 +40,12 @@ jobs:
           mkdir -p build/test-results
           flutter test --machine | tojunit --output build/test-results/flutter-junit.xml
 
+      - name: Run Flutter integration tests
+        run: |
+          mkdir -p build/integration-test-results
+          flutter test integration_test --machine | tojunit \
+            --output build/integration-test-results/flutter-integration-junit.xml
+
       - name: Run Android unit tests
         run: ./gradlew testDebugUnitTest
         working-directory: android
@@ -57,6 +63,12 @@ jobs:
         with:
           name: flutter-tests
           path: build/test-results/flutter-junit.xml
+
+      - name: Upload Flutter integration test results
+        uses: actions/upload-artifact@v3
+        with:
+          name: flutter-integration-tests
+          path: build/integration-test-results/flutter-integration-junit.xml
 
       - name: Upload Android test results
         uses: actions/upload-artifact@v3

--- a/integration_test/navigation_test.dart
+++ b/integration_test/navigation_test.dart
@@ -1,0 +1,57 @@
+import 'dart:convert';
+import 'dart:io';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:integration_test/integration_test.dart';
+import 'package:mana_reader/database/db_helper.dart';
+import 'package:mana_reader/main.dart';
+import 'package:mana_reader/models/book_model.dart';
+
+void main() {
+  IntegrationTestWidgetsFlutterBinding.ensureInitialized();
+
+  group('User journey', () {
+    late BookModel book;
+
+    setUpAll(() async {
+      final dir = await Directory.systemTemp.createTemp('mana_reader_test');
+      final imageFile = File('${dir.path}/page1.png');
+      // 1x1 transparent png
+      const base64Png =
+          'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8/x8AAwMB/ax5oQAAAABJRU5ErkJggg==';
+      await imageFile.writeAsBytes(base64Decode(base64Png));
+
+      book = BookModel(
+        title: 'Test Book',
+        path: dir.path,
+        language: 'en',
+        pages: [imageFile.path],
+      );
+      await DbHelper.instance.insertBook(book);
+    });
+
+    testWidgets('open book through library', (tester) async {
+      await tester.pumpWidget(const ManaReaderApp());
+      await tester.pumpAndSettle();
+
+      // Navigate to library
+      await tester.tap(find.text('Library'));
+      await tester.pumpAndSettle();
+      expect(find.text('Test Book'), findsOneWidget);
+
+      // Open the book
+      await tester.tap(find.text('Test Book'));
+      await tester.pumpAndSettle();
+      expect(find.text('Test Book'), findsWidgets);
+
+      // Navigate back to library and main menu
+      await tester.pageBack();
+      await tester.pumpAndSettle();
+      expect(find.text('Test Book'), findsOneWidget);
+      await tester.pageBack();
+      await tester.pumpAndSettle();
+      expect(find.text('Library'), findsOneWidget);
+    });
+  });
+}
+

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -120,6 +120,11 @@ packages:
     description: flutter
     source: sdk
     version: "0.0.0"
+  integration_test:
+    dependency: "direct dev"
+    description: flutter
+    source: sdk
+    version: "0.0.0"
   flutter_web_plugins:
     dependency: transitive
     description: flutter

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -30,6 +30,8 @@ dependencies:
 dev_dependencies:
   flutter_test:
     sdk: flutter
+  integration_test:
+    sdk: flutter
   flutter_lints: ^2.0.0
   sqflite_common_ffi: ^2.3.0
   path_provider_platform_interface: any


### PR DESCRIPTION
## Summary
- add integration test to cover main menu ➜ library ➜ reader navigation
- include integration_test package and run tests in CI

## Testing
- `flutter test integration_test` *(fails: command not found)*
- `apt-get install -y flutter` *(fails: Unable to locate package flutter)*

------
https://chatgpt.com/codex/tasks/task_e_689359a4bbe083268e962f4539bee406