### PR TITLE
Add Android instrumentation tests for MainActivity

### DIFF
--- a/android/app/build.gradle.kts
+++ b/android/app/build.gradle.kts
@@ -14,6 +14,7 @@ android {
         targetSdk = 33
         versionCode = 1
         versionName = "0.1.0"
+        testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
     }
 
     buildTypes {
@@ -33,4 +34,11 @@ android {
 
 flutter {
     source = "../.."
+}
+
+dependencies {
+    androidTestImplementation("androidx.test.ext:junit:1.1.5")
+    androidTestImplementation("androidx.test.espresso:espresso-core:3.5.1")
+    androidTestImplementation("androidx.test:rules:1.5.0")
+    androidTestImplementation("androidx.test:core:1.5.0")
 }

--- a/android/app/src/androidTest/java/com/example/mana_reader/MainActivityTest.kt
+++ b/android/app/src/androidTest/java/com/example/mana_reader/MainActivityTest.kt
@@ -1,0 +1,40 @@
+package com.example.mana_reader
+
+import androidx.lifecycle.Lifecycle
+import androidx.test.core.app.ActivityScenario
+import androidx.test.ext.junit.rules.ActivityScenarioRule
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import androidx.test.espresso.Espresso.onView
+import androidx.test.espresso.assertion.ViewAssertions.matches
+import androidx.test.espresso.matcher.ViewMatchers.isDisplayed
+import androidx.test.espresso.matcher.ViewMatchers.withId
+import org.junit.Assert.assertNotNull
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+
+@RunWith(AndroidJUnit4::class)
+class MainActivityTest {
+
+    @get:Rule
+    val activityRule = ActivityScenarioRule(MainActivity::class.java)
+
+    @Test
+    fun mainActivityLaunchesAndShowsSplash() {
+        activityRule.scenario.onActivity { activity ->
+            assertNotNull(activity)
+            // Splash screen background should be present when activity starts
+            assertNotNull(activity.window.decorView.background)
+        }
+        onView(withId(android.R.id.content)).check(matches(isDisplayed()))
+    }
+
+    @Test
+    fun mainActivityHandlesLifecycle() {
+        ActivityScenario.launch(MainActivity::class.java).use { scenario ->
+            scenario.moveToState(Lifecycle.State.RESUMED)
+            scenario.recreate()
+            scenario.moveToState(Lifecycle.State.DESTROYED)
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- add androidTest dependencies and instrumentation runner
- write MainActivity instrumentation tests

## Testing
- `./gradlew connectedAndroidTest` *(fails: gradle wrapper jar missing)*
- `gradle connectedAndroidTest --no-daemon --console=plain` *(fails: dev.flutter.flutter-gradle-plugin not found)*

------
https://chatgpt.com/codex/tasks/task_e_68935ba7c0488326854b3f54708799d4