### PR TITLE
chore: enforce test coverage threshold

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,7 +38,10 @@ jobs:
       - name: Run Flutter tests
         run: |
           mkdir -p build/test-results
-          flutter test --machine | tojunit --output build/test-results/flutter-junit.xml
+          flutter test --coverage --machine | tojunit --output build/test-results/flutter-junit.xml
+
+      - name: Check coverage
+        run: dart run tool/coverage_check.dart 80
 
       - name: Run Flutter integration tests
         run: |

--- a/tool/coverage_check.dart
+++ b/tool/coverage_check.dart
@@ -1,0 +1,36 @@
+import 'dart:io';
+
+void main(List<String> args) {
+  const coveragePath = 'coverage/lcov.info';
+  final coverageFile = File(coveragePath);
+  if (!coverageFile.existsSync()) {
+    stderr.writeln('Coverage file not found at $coveragePath. Run `flutter test --coverage` first.');
+    exit(1);
+  }
+
+  final lines = coverageFile.readAsLinesSync();
+  var totalFound = 0;
+  var totalHit = 0;
+
+  for (final line in lines) {
+    if (line.startsWith('LF:')) {
+      totalFound += int.parse(line.substring(3));
+    } else if (line.startsWith('LH:')) {
+      totalHit += int.parse(line.substring(3));
+    }
+  }
+
+  final coverage = totalFound == 0 ? 0 : (totalHit / totalFound * 100);
+  final threshold = args.isNotEmpty ? double.tryParse(args.first) ?? 80.0 : 80.0;
+
+  if (coverage < threshold) {
+    stderr.writeln(
+      'Coverage ${coverage.toStringAsFixed(2)}% is below the threshold of ${threshold.toStringAsFixed(2)}%.'
+    );
+    exit(1);
+  } else {
+    stdout.writeln(
+      'Coverage check passed: ${coverage.toStringAsFixed(2)}% >= ${threshold.toStringAsFixed(2)}%.'
+    );
+  }
+}

--- a/tool/test.sh
+++ b/tool/test.sh
@@ -1,5 +1,6 @@
 #!/usr/bin/env bash
-# Runs Flutter tests and outputs a JUnit XML report.
+# Runs Flutter tests with coverage and outputs a JUnit XML report.
 set -e
 mkdir -p build/test-results
-flutter test --machine | tojunit --output build/test-results/flutter-junit.xml
+flutter test --coverage --machine | tojunit --output build/test-results/flutter-junit.xml
+dart run tool/coverage_check.dart 80


### PR DESCRIPTION
## Summary
- add script to check lcov coverage and enforce threshold
- run flutter tests with coverage and verify minimum in CI
- update test script accordingly

## Testing
- `flutter format --set-exit-if-changed .` *(fails: command not found)*
- `flutter test --coverage` *(fails: command not found)*
- `dart run tool/coverage_check.dart 80` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68935ddd851c83269e12c20c00e679eb