### PR TITLE
chore: add pre-commit hooks

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,13 @@
+repos:
+  - repo: local
+    hooks:
+      - id: flutter-format
+        name: flutter format
+        entry: flutter format --set-exit-if-changed
+        language: system
+        types: [dart]
+      - id: flutter-analyze
+        name: flutter analyze
+        entry: flutter analyze
+        language: system
+        pass_filenames: false

--- a/README.md
+++ b/README.md
@@ -20,8 +20,13 @@ Mana Reader aims to be a lightweight, mobile manga and doujinshi reader built wi
    installation with `flutter doctor`.
 2. From the repository root run `flutter pub get` to fetch project
    dependencies.
-3. After dependencies are installed you can build or test the project using
+3. Install git hooks so formatting and analysis run before each commit:
+   `pre-commit install`.
+4. After dependencies are installed you can build or test the project using
    `flutter build` or `flutter test`.
+
+The pre-commit hooks run `flutter format` and `flutter analyze`. To check
+the entire repository manually, use `pre-commit run --all-files`.
 
 ## Running
 


### PR DESCRIPTION
## Summary
- add pre-commit config for flutter format and analyze
- document pre-commit workflow in README

## Testing
- `pre-commit install`
- `pre-commit run --all-files` *(fails: Could not find a command named "format" / dependency solving failed)*

------
https://chatgpt.com/codex/tasks/task_e_6893656f79848326b083669d057ce61c