### PR TITLE
ci: run workflow on pushes to main

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,6 +1,8 @@
 name: CI
 
 on:
+  push:
+    branches: [main]
   pull_request:
 
 jobs:


### PR DESCRIPTION
## Summary
- run CI on direct pushes to main branch

## Testing
- `pre-commit run --files .github/workflows/ci.yml` *(fails: junitreport requires intl ^0.17.0)*
- `flutter test` *(fails: junitreport requires intl ^0.17.0)*

------
https://chatgpt.com/codex/tasks/task_e_68936b055d308326a04c51bffa0e5a87