### PR TITLE
Remove junitreport to resolve intl dependency conflict

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,6 +32,7 @@ migrate_working_dir/
 .pub/
 /build/
 /coverage/
+lib/l10n/*.dart
 
 # Symbolication related
 app.*.symbols

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -9,14 +9,6 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "3.6.1"
-  args:
-    dependency: transitive
-    description:
-      name: args
-      sha256: "d0481093c50b1da8910eb0bb301626d4d8eb7284aa739614d2b394ee09e3ea04"
-      url: "https://pub.dev"
-    source: hosted
-    version: "2.7.0"
   async:
     dependency: transitive
     description:
@@ -81,6 +73,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.1.4"
+  file:
+    dependency: transitive
+    description:
+      name: file
+      sha256: a3b4f84adafef897088c160faf7dfffb7696046cb13ae90b508c2cbc95d3b8d4
+      url: "https://pub.dev"
+    source: hosted
+    version: "7.0.1"
   file_picker:
     dependency: "direct main"
     description:
@@ -91,6 +91,11 @@ packages:
     version: "3.0.4"
   flutter:
     dependency: "direct main"
+    description: flutter
+    source: sdk
+    version: "0.0.0"
+  flutter_driver:
+    dependency: transitive
     description: flutter
     source: sdk
     version: "0.0.0"
@@ -120,12 +125,12 @@ packages:
     description: flutter
     source: sdk
     version: "0.0.0"
-  integration_test:
-    dependency: "direct dev"
+  flutter_web_plugins:
+    dependency: transitive
     description: flutter
     source: sdk
     version: "0.0.0"
-  flutter_web_plugins:
+  fuchsia_remote_debug_protocol:
     dependency: transitive
     description: flutter
     source: sdk
@@ -146,6 +151,11 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "4.1.2"
+  integration_test:
+    dependency: "direct dev"
+    description: flutter
+    source: sdk
+    version: "0.0.0"
   intl:
     dependency: "direct main"
     description:
@@ -162,14 +172,6 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "0.6.7"
-  junitreport:
-    dependency: "direct dev"
-    description:
-      name: junitreport
-      sha256: "139a457f5d91e82744df09d04f272d23b6a81c8ef9b8b3bd1cd2e1768460fbeb"
-      url: "https://pub.dev"
-    source: hosted
-    version: "2.0.2"
   leak_tracker:
     dependency: transitive
     description:
@@ -354,6 +356,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.1.8"
+  process:
+    dependency: transitive
+    description:
+      name: process
+      sha256: "107d8be718f120bbba9dcd1e95e3bd325b1b4a4f07db64154635ba03f2567a0d"
+      url: "https://pub.dev"
+    source: hosted
+    version: "5.0.3"
   rar:
     dependency: "direct main"
     description:
@@ -455,6 +465,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.4.1"
+  sync_http:
+    dependency: transitive
+    description:
+      name: sync_http
+      sha256: "7f0cd72eca000d2e026bcd6f990b81d0ca06022ef4e32fb257b30d3d1014a961"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.3.1"
   synchronized:
     dependency: transitive
     description:
@@ -479,14 +497,6 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "0.7.4"
-  testreport:
-    dependency: transitive
-    description:
-      name: testreport
-      sha256: "d9b9af11e591d15724f63324b7957e6b36c04cca293147db7761064bbf363b0d"
-      url: "https://pub.dev"
-    source: hosted
-    version: "2.0.1"
   typed_data:
     dependency: transitive
     description:
@@ -519,6 +529,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.1.1"
+  webdriver:
+    dependency: transitive
+    description:
+      name: webdriver
+      sha256: "2f3a14ca026957870cfd9c635b83507e0e51d8091568e90129fbf805aba7cade"
+      url: "https://pub.dev"
+    source: hosted
+    version: "3.1.0"
   xdg_directories:
     dependency: transitive
     description:
@@ -527,14 +545,6 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.1.0"
-  xml:
-    dependency: transitive
-    description:
-      name: xml
-      sha256: "80d494c09849dc3f899d227a78c30c5b949b985ededf884cb3f3bcd39f4b447a"
-      url: "https://pub.dev"
-    source: hosted
-    version: "5.4.1"
 sdks:
   dart: ">=3.8.0 <4.0.0"
   flutter: ">=3.27.0"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -36,7 +36,6 @@ dev_dependencies:
   sqflite_common_ffi: ^2.3.0
   path_provider_platform_interface: any
   pdf_render_platform_interface: any
-  junitreport: ^2.0.2
 
 flutter:
   uses-material-design: true


### PR DESCRIPTION
## Summary
- remove `junitreport` dev dependency so `intl` resolves correctly
- ignore generated l10n Dart files

## Testing
- `flutter test test/importer_test.dart` *(fails: Unsupported archive type; MissingPluginException for pdf_render)*

------
https://chatgpt.com/codex/tasks/task_e_68936e5d5b7c8326acc7635836a07094