### PR TITLE
feat: show import prompt when library empty

### DIFF
--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -33,5 +33,7 @@
   "fitWidth": "Fit Width",
   "clear": "Clear",
   "pageLoadFailed": "Failed to load page {page}",
-  "continueReading": "Continue Reading"
+  "continueReading": "Continue Reading",
+  "importFile": "Import File",
+  "syncDirectory": "Sync Directory"
 }

--- a/lib/screens/history_screen.dart
+++ b/lib/screens/history_screen.dart
@@ -1,3 +1,5 @@
+import 'dart:io';
+
 import 'package:flutter/material.dart';
 import '../l10n/app_localizations.dart';
 
@@ -10,6 +12,7 @@ class HistoryScreen extends StatelessWidget {
   HistoryScreen({super.key});
 
   final Map<String, Future<double>> _progressCache = {};
+  final Map<String, Future<String?>> _thumbCache = {};
 
   Future<List<BookModel>> _fetchHistory() {
     return DbHelper.instance.fetchHistoryBooks();
@@ -19,11 +22,41 @@ class HistoryScreen extends StatelessWidget {
     return _progressCache[book.path] ??= _loadProgress(book);
   }
 
+  Future<String?> _thumbnailFor(BookModel book) {
+    return _thumbCache[book.path] ??= _loadThumbnail(book);
+  }
+
   Future<double> _loadProgress(BookModel book) async {
     final count = book.pages.length;
     if (count == 0) return 0;
     final progress = book.lastPage / count;
     return progress.clamp(0, 1).toDouble();
+  }
+
+  Future<String?> _loadThumbnail(BookModel book) async {
+    if (book.pages.isNotEmpty) {
+      return book.pages.first;
+    }
+    final dir = Directory(book.path);
+    if (!await dir.exists()) return null;
+    try {
+      await for (final entity in dir.list(recursive: true)) {
+        if (entity is File && _isImage(entity.path)) {
+          return entity.path;
+        }
+      }
+    } catch (e) {
+      debugPrint('Failed to load thumbnail for ${book.path}: $e');
+    }
+    return null;
+  }
+
+  bool _isImage(String path) {
+    final lower = path.toLowerCase();
+    return lower.endsWith('.jpg') ||
+        lower.endsWith('.jpeg') ||
+        lower.endsWith('.png') ||
+        lower.endsWith('.gif');
   }
 
   @override
@@ -40,25 +73,59 @@ class HistoryScreen extends StatelessWidget {
           if (books.isEmpty) {
             return Center(child: Text(AppLocalizations.of(context)!.noHistory));
           }
+          final recent = books.take(6).toList();
           return ListView.builder(
-            itemCount: books.length,
+            itemCount: recent.length,
             itemBuilder: (context, index) {
-              final book = books[index];
+              final book = recent[index];
               return ListTile(
+                leading: FutureBuilder<String?>(
+                  future: _thumbnailFor(book),
+                  builder: (context, snap) {
+                    if (snap.connectionState != ConnectionState.done) {
+                      return Container(
+                        width: 50,
+                        height: 70,
+                        color: Colors.grey.shade800,
+                        alignment: Alignment.center,
+                        child: const CircularProgressIndicator(),
+                      );
+                    }
+                    if (snap.hasError) {
+                      return Container(
+                        width: 50,
+                        height: 70,
+                        color: Colors.grey.shade800,
+                        alignment: Alignment.center,
+                        child: const Icon(Icons.broken_image),
+                      );
+                    }
+                    final path = snap.data;
+                    if (path != null) {
+                      return Image.file(File(path), width: 50, height: 70, fit: BoxFit.cover);
+                    }
+                    return Container(
+                      width: 50,
+                      height: 70,
+                      color: Colors.grey.shade800,
+                      alignment: Alignment.center,
+                      child: const Icon(Icons.image_not_supported),
+                    );
+                  },
+                ),
                 title: Text(book.title),
+                subtitle: book.author.isNotEmpty ? Text(book.author) : null,
                 trailing: FutureBuilder<double>(
                   future: _progressFor(book),
                   builder: (context, snap) {
                     final value = snap.data ?? 0.0;
                     final percent = (value * 100).round();
                     return Container(
-                      padding:
-                          const EdgeInsets.symmetric(horizontal: 4, vertical: 2),
+                      padding: const EdgeInsets.symmetric(horizontal: 4, vertical: 2),
                       color: Colors.black54,
                       child: Text(
                         '$percent%',
-                        style:
-                            const TextStyle(fontSize: 12, color: Colors.white),
+                        style: const TextStyle(fontSize: 12, color: Colors.white),
                       ),
                     );
                   },

--- a/lib/screens/library_screen.dart
+++ b/lib/screens/library_screen.dart
@@ -138,6 +138,27 @@ class _LibraryScreenState extends State<LibraryScreen> {
         lower.endsWith('.gif');
   }
 
+  Widget _buildEmptyState() {
+    return Center(
+      child: Column(
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          Text(AppLocalizations.of(context)!.noBooks),
+          const SizedBox(height: 16),
+          ElevatedButton(
+            onPressed: _pickAndImport,
+            child: Text(AppLocalizations.of(context)!.importFile),
+          ),
+          const SizedBox(height: 8),
+          ElevatedButton(
+            onPressed: _syncDirectory,
+            child: Text(AppLocalizations.of(context)!.syncDirectory),
+          ),
+        ],
+      ),
+    );
+  }
+
   @override
   Widget build(BuildContext context) {
     return Scaffold(
@@ -197,7 +218,7 @@ class _LibraryScreenState extends State<LibraryScreen> {
           }
           final books = snapshot.data!;
           if (books.isEmpty) {
-            return Center(child: Text(AppLocalizations.of(context)!.noBooks));
+            return _buildEmptyState();
           }
           Widget listWidget;
           if (_isGrid) {


### PR DESCRIPTION
## Summary
- show import options when library has no books
- display up to six recent items with cover art on history screen
- localize new import button labels

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68940d40c9dc83269dc0f9c5e758651d