### PR TITLE
Remove LFS pointers and assets

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -9,7 +9,6 @@
 *.mp3 filter=lfs diff=lfs merge=lfs -text
 *.wav filter=lfs diff=lfs merge=lfs -text
 *.ogg filter=lfs diff=lfs merge=lfs -text
-*.png filter=lfs diff=lfs merge=lfs -text
 *.gif filter=lfs diff=lfs merge=lfs -text
 *.7z filter=lfs diff=lfs merge=lfs -text
 *.rar filter=lfs diff=lfs merge=lfs -text
@@ -19,4 +18,3 @@
 *.avi filter=lfs diff=lfs merge=lfs -text
 *.jpg filter=lfs diff=lfs merge=lfs -text
 *.ico filter=lfs diff=lfs merge=lfs -text
-*.pdf filter=lfs diff=lfs merge=lfs -text

--- a/android/app/src/main/res/mipmap-hdpi/ic_launcher.png
+++ b/android/app/src/main/res/mipmap-hdpi/ic_launcher.png
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:5ef860d75bf8ba185635f9fbb572b0d77de3c73d45424d4df8d44c5de5ff1c91
-size 242

--- a/android/app/src/main/res/mipmap-mdpi/ic_launcher.png
+++ b/android/app/src/main/res/mipmap-mdpi/ic_launcher.png
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:a7d50b1b9f68e21ce88d929bf0f8b83844da0fe703db970731360a51d7f4201f
-size 155

--- a/android/app/src/main/res/mipmap-xhdpi/ic_launcher.png
+++ b/android/app/src/main/res/mipmap-xhdpi/ic_launcher.png
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:5cbe0b99d534b98a5cde3f89e06ed12e9fc3a9e2e856d658387b2092268c0f14
-size 303

--- a/android/app/src/main/res/mipmap-xxhdpi/ic_launcher.png
+++ b/android/app/src/main/res/mipmap-xxhdpi/ic_launcher.png
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:627d5bea1a82b887e28a449b94912f3e6360ff404a6161fd445df13389beb780
-size 447

--- a/android/app/src/main/res/mipmap-xxxhdpi/ic_launcher.png
+++ b/android/app/src/main/res/mipmap-xxxhdpi/ic_launcher.png
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:c25b82c316c1ae1103199035815db12fcd929ce453829ad5898dd600b65eb042
-size 605

--- a/assets/sample_books/dummy_story.pdf
+++ b/assets/sample_books/dummy_story.pdf
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:f826dcbf1fb0bc6dc55feac6df8c4c5beeaedfd1a37a1b812574a90539575a58
-size 2012


### PR DESCRIPTION
## Summary
- untrack png and pdf files from Git LFS
- remove Android launcher icons and sample PDF to avoid binary files in repo

## Testing
- `apt-get update -qq && apt-get install -y flutter` *(fails: Unable to locate package flutter)*
- `pre-commit run --files .gitattributes` *(fails: Executable `flutter` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6894c5e0b61c8326869918f4546a2957