### PR TITLE
Switch PDF rendering to native_pdf_renderer

### DIFF
--- a/pubspec.lock
+++ b/pubspec.lock
@@ -284,22 +284,6 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.3.0"
-  pdf_render:
-    dependency: "direct main"
-    description:
-      name: pdf_render
-      sha256: bacd2ad8f4f4c9821827003065f5c2f9ca474dd418ff29c68272aab4c0e1e88b
-      url: "https://pub.dev"
-    source: hosted
-    version: "1.4.12"
-  pdf_render_platform_interface:
-    dependency: "direct dev"
-    description:
-      name: pdf_render_platform_interface
-      sha256: "67bf2a50a0db4f04f242f5eb6ac5f08541e1d603985c93b8154cdaa88111d3c3"
-      url: "https://pub.dev"
-    source: hosted
-    version: "1.0.2-dev"
   permission_handler:
     dependency: "direct main"
     description:

--- a/test/archive_importer_test.dart
+++ b/test/archive_importer_test.dart
@@ -1,54 +1,42 @@
 import 'dart:convert';
 import 'dart:io';
 import 'dart:typed_data';
-import 'dart:ffi';
-import 'dart:ui' as ui;
 import 'dart:async';
 
 import 'package:flutter_test/flutter_test.dart';
 import 'package:path/path.dart' as p;
 import 'package:path_provider_platform_interface/path_provider_platform_interface.dart';
 import 'package:archive/archive.dart';
-import 'package:pdf_render_platform_interface/pdf_render.dart';
-import 'package:pdf_render_platform_interface/pdf_render_platform_interface.dart';
+import 'package:native_pdf_renderer/native_pdf_renderer.dart';
+import 'package:native_pdf_renderer/src/renderer/interfaces/platform.dart';
 
 import 'package:mana_reader/importers/seven_zip_importer.dart';
 import 'package:mana_reader/importers/pdf_importer.dart';
 
-class _FakePdfRenderPlatform extends PdfRenderPlatform {
+class _FakePdfxPlatform extends PdfxPlatform {
   @override
-  Future<PdfDocument?> openFile(String filePath) async => _FakePdfDocument();
+  Future<PdfDocument> openFile(String filePath, {String? password}) async =>
+      _FakePdfDocument();
 
   @override
-  Future<PdfDocument?> openAsset(String name) async => _FakePdfDocument();
+  Future<PdfDocument> openAsset(String name, {String? password}) async =>
+      _FakePdfDocument();
 
   @override
-  Future<PdfDocument?> openData(Uint8List data) async => _FakePdfDocument();
-
-  @override
-  Future<PdfPageImageTexture> createTexture({
-    required PdfDocument pdfDocument,
-    required int pageNumber,
-  }) => throw UnimplementedError();
+  Future<PdfDocument> openData(FutureOr<Uint8List> data,
+          {String? password}) async =>
+      _FakePdfDocument();
 }
 
 class _FakePdfDocument extends PdfDocument {
   _FakePdfDocument()
-    : super(
-        sourceName: 'fake.pdf',
-        pageCount: 1,
-        verMajor: 1,
-        verMinor: 7,
-        isEncrypted: false,
-        allowsCopying: true,
-        allowsPrinting: true,
-      );
+      : super(sourceName: 'fake.pdf', id: '1', pagesCount: 1);
 
   @override
-  Future<void> dispose() async {}
+  Future<void> close() async {}
 
   @override
-  Future<PdfPage> getPage(int pageNumber) async =>
+  Future<PdfPage> getPage(int pageNumber, {bool autoCloseAndroid = false}) async =>
       _FakePdfPage(this, pageNumber);
 
   @override
@@ -60,72 +48,56 @@ class _FakePdfDocument extends PdfDocument {
 
 class _FakePdfPage extends PdfPage {
   _FakePdfPage(PdfDocument doc, int num)
-    : super(document: doc, pageNumber: num, width: 1, height: 1);
+      : super(
+          document: doc,
+          id: 'page$num',
+          pageNumber: num,
+          width: 1,
+          height: 1,
+          autoCloseAndroid: false,
+        );
 
   @override
-  Future<PdfPageImage> render({
-    int? x,
-    int? y,
-    int? width,
-    int? height,
-    double? fullWidth,
-    double? fullHeight,
-    bool? backgroundFill,
+  Future<PdfPageImage?> render({
+    required double width,
+    required double height,
+    PdfPageImageFormat format = PdfPageImageFormat.jpeg,
+    String? backgroundColor,
+    Rect? cropRect,
+    int quality = 100,
+    bool forPrint = false,
+    bool removeTempFile = true,
   }) async {
-    return _FakePdfPageImage(pageNumber);
+    final bytes = base64Decode(
+        'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8Xw8AAiMB7g6lbYkAAAAASUVORK5CYII=');
+    return _FakePdfPageImage(pageNumber, bytes, format, quality);
   }
 
+  @override
+  Future<PdfPageTexture> createTexture() => throw UnimplementedError();
+
+  @override
   Future<void> close() async {}
 }
 
 class _FakePdfPageImage extends PdfPageImage {
-  _FakePdfPageImage(int page)
-    : _pixels = Uint8List.fromList(const [255, 0, 0, 255]),
-      super(
-        pageNumber: page,
-        x: 0,
-        y: 0,
-        width: 1,
-        height: 1,
-        fullWidth: 1,
-        fullHeight: 1,
-        pageWidth: 1,
-        pageHeight: 1,
-      );
-
-  final Uint8List _pixels;
-  ui.Image? _image;
+  _FakePdfPageImage(
+      int page, Uint8List bytes, PdfPageImageFormat format, int quality)
+      : super(
+          id: 'img$page',
+          pageNumber: page,
+          width: 1,
+          height: 1,
+          bytes: bytes,
+          format: format,
+          quality: quality,
+        );
 
   @override
-  Uint8List get pixels => _pixels;
+  bool operator ==(Object other) => identical(this, other);
 
   @override
-  Pointer<Uint8>? get buffer => null;
-
-  @override
-  void dispose() {}
-
-  @override
-  ui.Image? get imageIfAvailable => _image;
-
-  @override
-  Future<ui.Image> createImageIfNotAvailable() async {
-    if (_image != null) return _image!;
-    final comp = Completer<ui.Image>();
-    ui.decodeImageFromPixels(
-      _pixels,
-      1,
-      1,
-      ui.PixelFormat.rgba8888,
-      (img) => comp.complete(img),
-    );
-    _image = await comp.future;
-    return _image!;
-  }
-
-  @override
-  Future<ui.Image> createImageDetached() async =>
-      await createImageIfNotAvailable();
+  int get hashCode => super.hashCode;
 }
 
 class _FakePathProviderPlatform extends PathProviderPlatform {
@@ -227,7 +199,7 @@ void main() {
     );
 
     test('PdfImporter renders pages from small PDF', () async {
-      PdfRenderPlatform.instance = _FakePdfRenderPlatform();
+      PdfxPlatform.instance = _FakePdfxPlatform();
       final tmp = Directory.systemTemp.createTempSync();
       final pdfData = base64Decode(
         'JVBERi0xLjEKMSAwIG9iajw8L1R5cGUvQ2F0YWxvZy9QYWdlcyAyIDAgUj4+ZW5kb2JqCjIgMCBvYmo8PC9UeXBlL1BhZ2VzL0tpZHNbMyAwIFJdL0NvdW50IDE+PmVuZG9iagozIDAgb2JqPDwvVHlwZS9QYWdlL1BhcmVudCAyIDAgUi9NZWRpYUJveFswIDAgNjEyIDc5Ml0+PmVuZG9iagp0cmFpbGVyPDwvUm9vdCAxIDAgUi9TaXplIDQ+PgolJUVPRg==',

--- a/test/sync_service_test.dart
+++ b/test/sync_service_test.dart
@@ -1,9 +1,7 @@
 import 'dart:convert';
 import 'dart:io';
 import 'dart:async';
-import 'dart:ffi';
 import 'dart:typed_data';
-import 'dart:ui' as ui;
 
 import 'package:flutter_test/flutter_test.dart';
 import 'package:mana_reader/importers/seven_zip_importer.dart';
@@ -11,43 +9,37 @@ import 'package:path/path.dart' as p;
 import 'package:path_provider_platform_interface/path_provider_platform_interface.dart';
 import 'package:sqflite_common_ffi/sqflite_ffi.dart';
 import 'package:archive/archive.dart';
-import 'package:pdf_render_platform_interface/pdf_render.dart';
-import 'package:pdf_render_platform_interface/pdf_render_platform_interface.dart';
+import 'package:native_pdf_renderer/native_pdf_renderer.dart';
+import 'package:native_pdf_renderer/src/renderer/interfaces/platform.dart';
 
 import 'package:mana_reader/import/sync_service.dart';
 import 'package:mana_reader/database/db_helper.dart';
 
-class _FakePdfRenderPlatform extends PdfRenderPlatform {
+class _FakePdfxPlatform extends PdfxPlatform {
   @override
-  Future<PdfDocument?> openFile(String filePath) async => _FakePdfDocument();
+  Future<PdfDocument> openFile(String filePath, {String? password}) async =>
+      _FakePdfDocument();
 
   @override
-  Future<PdfDocument?> openAsset(String name) async => _FakePdfDocument();
+  Future<PdfDocument> openAsset(String name, {String? password}) async =>
+      _FakePdfDocument();
 
   @override
-  Future<PdfDocument?> openData(Uint8List data) async => _FakePdfDocument();
-
-  @override
-  Future<PdfPageImageTexture> createTexture({required PdfDocument pdfDocument, required int pageNumber}) =>
-      throw UnimplementedError();
+  Future<PdfDocument> openData(FutureOr<Uint8List> data,
+          {String? password}) async =>
+      _FakePdfDocument();
 }
 
 class _FakePdfDocument extends PdfDocument {
   _FakePdfDocument()
-      : super(
-            sourceName: 'fake.pdf',
-            pageCount: 1,
-            verMajor: 1,
-            verMinor: 7,
-            isEncrypted: false,
-            allowsCopying: true,
-            allowsPrinting: true);
+      : super(sourceName: 'fake.pdf', id: '1', pagesCount: 1);
 
   @override
-  Future<void> dispose() async {}
+  Future<void> close() async {}
 
   @override
-  Future<PdfPage> getPage(int pageNumber) async => _FakePdfPage(this, pageNumber);
+  Future<PdfPage> getPage(int pageNumber, {bool autoCloseAndroid = false}) async =>
+      _FakePdfPage(this, pageNumber);
 
   @override
   bool operator ==(Object other) => identical(this, other);
@@ -58,65 +50,56 @@ class _FakePdfDocument extends PdfDocument {
 
 class _FakePdfPage extends PdfPage {
   _FakePdfPage(PdfDocument doc, int num)
-      : super(document: doc, pageNumber: num, width: 1, height: 1);
+      : super(
+          document: doc,
+          id: 'page$num',
+          pageNumber: num,
+          width: 1,
+          height: 1,
+          autoCloseAndroid: false,
+        );
 
   @override
-  Future<PdfPageImage> render({
-    int? x,
-    int? y,
-    int? width,
-    int? height,
-    double? fullWidth,
-    double? fullHeight,
-    bool? backgroundFill,
+  Future<PdfPageImage?> render({
+    required double width,
+    required double height,
+    PdfPageImageFormat format = PdfPageImageFormat.jpeg,
+    String? backgroundColor,
+    Rect? cropRect,
+    int quality = 100,
+    bool forPrint = false,
+    bool removeTempFile = true,
   }) async {
-    return _FakePdfPageImage(pageNumber);
+    final bytes = base64Decode(
+        'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8Xw8AAiMB7g6lbYkAAAAASUVORK5CYII=');
+    return _FakePdfPageImage(pageNumber, bytes, format, quality);
   }
 
+  @override
+  Future<PdfPageTexture> createTexture() => throw UnimplementedError();
+
+  @override
   Future<void> close() async {}
 }
 
 class _FakePdfPageImage extends PdfPageImage {
-  _FakePdfPageImage(int page)
-      : _pixels = Uint8List.fromList(const [255, 0, 0, 255]),
-        super(
-            pageNumber: page,
-            x: 0,
-            y: 0,
-            width: 1,
-            height: 1,
-            fullWidth: 1,
-            fullHeight: 1,
-            pageWidth: 1,
-            pageHeight: 1);
-
-  final Uint8List _pixels;
-  ui.Image? _image;
+  _FakePdfPageImage(
+      int page, Uint8List bytes, PdfPageImageFormat format, int quality)
+      : super(
+          id: 'img$page',
+          pageNumber: page,
+          width: 1,
+          height: 1,
+          bytes: bytes,
+          format: format,
+          quality: quality,
+        );
 
   @override
-  Uint8List get pixels => _pixels;
+  bool operator ==(Object other) => identical(this, other);
 
   @override
-  Pointer<Uint8>? get buffer => null;
-
-  @override
-  void dispose() {}
-
-  @override
-  ui.Image? get imageIfAvailable => _image;
-
-  @override
-  Future<ui.Image> createImageIfNotAvailable() async {
-    if (_image != null) return _image!;
-    final comp = Completer<ui.Image>();
-    ui.decodeImageFromPixels(
-        _pixels, 1, 1, ui.PixelFormat.rgba8888, (img) => comp.complete(img));
-    _image = await comp.future;
-    return _image!;
-  }
-
-  @override
-  Future<ui.Image> createImageDetached() async => await createImageIfNotAvailable();
+  int get hashCode => super.hashCode;
 }
 
 class _FakePathProviderPlatform extends PathProviderPlatform {
@@ -136,7 +119,7 @@ void main() {
 
   setUp(() {
     PathProviderPlatform.instance = _FakePathProviderPlatform();
-    PdfRenderPlatform.instance = _FakePdfRenderPlatform();
+    PdfxPlatform.instance = _FakePdfxPlatform();
     processRun = (String exe, List<String> args) async {
       if (exe == 'which' || exe == 'where') {
         return ProcessResult(0, 0, '', '');


### PR DESCRIPTION
## Summary
- replace deprecated `pdf_render` with `native_pdf_renderer`
- rewrite PDF importer using `PdfDocument.openFile` and `page.render`
- adjust tests to mock `native_pdf_renderer` platform APIs

## Testing
- `dart pub get` *(fails: command not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6894fd8bad0c83269792a13928ae8344