### PR TITLE
Enable sqflite FFI on desktop and simplify tests

### DIFF
--- a/lib/database/db_helper.dart
+++ b/lib/database/db_helper.dart
@@ -4,6 +4,8 @@ import 'package:flutter/foundation.dart';
 import 'package:path/path.dart' as p;
 import 'package:path_provider/path_provider.dart';
 import 'package:sqflite/sqflite.dart';
+import 'package:sqflite_common_ffi/sqflite_ffi.dart';
+import 'package:sqflite_common_ffi_web/sqflite_ffi_web.dart';
 
 import '../models/book_model.dart';
 import '../metadata/metadata_service.dart';
@@ -25,6 +27,12 @@ class DbHelper {
   }
 
   Future<Database> _initDb() async {
+    if (kIsWeb) {
+      databaseFactory = databaseFactoryFfiWeb;
+    } else if (Platform.isWindows || Platform.isLinux || Platform.isMacOS) {
+      sqfliteFfiInit();
+      databaseFactory = databaseFactoryFfi;
+    }
     final documentsDir = await getApplicationDocumentsDirectory();
     final path = p.join(documentsDir.path, 'mana_reader.db');
     return openDatabase(

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -17,6 +17,7 @@ dependencies:
   permission_handler: ^12.0.1
   sqflite: ^2.3.2
   sqflite_common_ffi: ^2.3.0
+  sqflite_common_ffi_web: ^1.0.1
   flutter_localizations:
     sdk: flutter
   intl: ^0.20.2

--- a/test/db_helper_test.dart
+++ b/test/db_helper_test.dart
@@ -2,7 +2,6 @@ import 'dart:io';
 
 import 'package:flutter_test/flutter_test.dart';
 import 'package:path_provider_platform_interface/path_provider_platform_interface.dart';
-import 'package:sqflite_common_ffi/sqflite_ffi.dart';
 
 import 'package:mana_reader/database/db_helper.dart';
 import 'package:mana_reader/models/book_model.dart';
@@ -28,8 +27,6 @@ class _FakeMetadataService extends MetadataService {
 
 void main() {
   TestWidgetsFlutterBinding.ensureInitialized();
-  sqfliteFfiInit();
-  databaseFactory = databaseFactoryFfi;
   PathProviderPlatform.instance = _FakePathProviderPlatform();
 
   group('DbHelper', () {

--- a/test/library_screen_test.dart
+++ b/test/library_screen_test.dart
@@ -7,7 +7,6 @@ import 'package:path_provider_platform_interface/path_provider_platform_interfac
 import 'package:mana_reader/models/book_model.dart';
 import 'package:mana_reader/screens/library_screen.dart';
 import 'package:mana_reader/database/db_helper.dart';
-import 'package:sqflite_common_ffi/sqflite_ffi.dart';
 
 class _FakePathProviderPlatform extends PathProviderPlatform {
   final Directory tempDir =
@@ -110,9 +109,6 @@ void main() {
 
   testWidgets('filters by language', (tester) async {
     final fakeDb = DbHelper();
-    // Initialize ffi for db usage
-    sqfliteFfiInit();
-    databaseFactory = databaseFactoryFfi;
     PathProviderPlatform.instance = _FakePathProviderPlatform();
     await fakeDb.insertBook(BookModel(title: 'EN', path: '/tmp/en.cbz', language: 'en'));
     await fakeDb.insertBook(BookModel(title: 'JP', path: '/tmp/jp.cbz', language: 'jp'));
@@ -166,8 +162,6 @@ void main() {
 
   testWidgets('filters by multiple tags', (tester) async {
     final fakeDb = DbHelper();
-    sqfliteFfiInit();
-    databaseFactory = databaseFactoryFfi;
     PathProviderPlatform.instance = _FakePathProviderPlatform();
     await fakeDb.insertBook(BookModel(
         title: 'A', path: '/tmp/a.cbz', language: 'en', tags: ['a']));

--- a/test/sync_service_test.dart
+++ b/test/sync_service_test.dart
@@ -7,7 +7,6 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:mana_reader/importers/seven_zip_importer.dart';
 import 'package:path/path.dart' as p;
 import 'package:path_provider_platform_interface/path_provider_platform_interface.dart';
-import 'package:sqflite_common_ffi/sqflite_ffi.dart';
 import 'package:archive/archive.dart';
 import 'package:native_pdf_renderer/native_pdf_renderer.dart';
 import 'package:native_pdf_renderer/src/renderer/interfaces/platform.dart';
@@ -111,8 +110,6 @@ class _FakePathProviderPlatform extends PathProviderPlatform {
 
 void main() {
   TestWidgetsFlutterBinding.ensureInitialized();
-  sqfliteFfiInit();
-  databaseFactory = databaseFactoryFfi;
   PathProviderPlatform.instance = _FakePathProviderPlatform();
 
   const imgData = 'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8Xw8AAiMB7g6lbYkAAAAASUVORK5CYII=';


### PR DESCRIPTION
## Summary
- initialize sqflite FFI and web factories in `DbHelper`
- add `sqflite_common_ffi_web` dependency
- remove manual FFI setup from tests

## Testing
- `flutter pub get` *(fails: command not found)*
- `dart format lib/database/db_helper.dart test/db_helper_test.dart test/library_screen_test.dart test/sync_service_test.dart pubspec.yaml` *(fails: command not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68950860a4c083268fbc567763b0b525