### PR TITLE
Refactor navigation to GoRouter with Material3 theme

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,8 +1,16 @@
 import 'package:flutter/material.dart';
-import 'screens/main_menu.dart';
 import 'package:flutter_localizations/flutter_localizations.dart';
-import 'l10n/app_localizations.dart';
+import 'package:go_router/go_router.dart';
+
 import 'database/db_helper.dart';
+import 'l10n/app_localizations.dart';
+import 'models/book_model.dart';
+import 'screens/book_detail_screen.dart';
+import 'screens/bookmarks_screen.dart';
+import 'screens/history_screen.dart';
+import 'screens/library_screen.dart';
+import 'screens/main_menu.dart';
+import 'screens/reader_screen.dart';
 
 void main() => runApp(const ManaReaderApp());
 
@@ -14,6 +22,43 @@ class ManaReaderApp extends StatefulWidget {
 }
 
 class _ManaReaderAppState extends State<ManaReaderApp> {
+  late final GoRouter _router = GoRouter(
+    routes: [
+      GoRoute(
+        path: '/',
+        builder: (context, state) => const MainMenu(),
+      ),
+      GoRoute(
+        path: '/library',
+        builder: (context, state) => const LibraryScreen(),
+      ),
+      GoRoute(
+        path: '/history',
+        builder: (context, state) => HistoryScreen(),
+      ),
+      GoRoute(
+        path: '/reader',
+        builder: (context, state) {
+          final book = state.extra as BookModel;
+          return ReaderScreen(book: book);
+        },
+      ),
+      GoRoute(
+        path: '/book',
+        builder: (context, state) {
+          final book = state.extra as BookModel;
+          return BookDetailScreen(book: book);
+        },
+      ),
+      GoRoute(
+        path: '/bookmarks',
+        builder: (context, state) {
+          final book = state.extra as BookModel;
+          return BookmarksScreen(book: book);
+        },
+      ),
+    ],
+  );
   @override
   void dispose() {
     DbHelper.instance.close();
@@ -22,12 +67,18 @@ class _ManaReaderAppState extends State<ManaReaderApp> {
 
   @override
   Widget build(BuildContext context) {
-    return MaterialApp(
+    return MaterialApp.router(
       onGenerateTitle: (context) => AppLocalizations.of(context)!.appTitle,
-      theme: ThemeData.dark(),
+      theme: ThemeData(
+        colorScheme: ColorScheme.fromSeed(
+          seedColor: Colors.deepPurple,
+          brightness: Brightness.dark,
+        ),
+        useMaterial3: true,
+      ),
       localizationsDelegates: AppLocalizations.localizationsDelegates,
       supportedLocales: AppLocalizations.supportedLocales,
-      home: const MainMenu(),
+      routerConfig: _router,
     );
   }
 }

--- a/lib/screens/book_detail_screen.dart
+++ b/lib/screens/book_detail_screen.dart
@@ -1,7 +1,8 @@
 import 'package:flutter/material.dart';
-import '../l10n/app_localizations.dart';
+import 'package:go_router/go_router.dart';
 
 import '../database/db_helper.dart';
+import '../l10n/app_localizations.dart';
 import '../models/book_model.dart';
 
 /// Displays and edits metadata for a [BookModel].
@@ -54,7 +55,7 @@ class _BookDetailScreenState extends State<BookDetailScreen> {
       pages: widget.book.pages,
     );
     await DbHelper.instance.updateBook(updated);
-    if (mounted) Navigator.pop(context, updated);
+    if (mounted) context.pop(updated);
   }
 
   @override

--- a/lib/screens/bookmarks_screen.dart
+++ b/lib/screens/bookmarks_screen.dart
@@ -1,7 +1,8 @@
 import 'package:flutter/material.dart';
-import '../l10n/app_localizations.dart';
+import 'package:go_router/go_router.dart';
 
 import '../database/db_helper.dart';
+import '../l10n/app_localizations.dart';
 import '../models/book_model.dart';
 
 /// Lists bookmarked pages for a book and returns the selected page index.
@@ -35,7 +36,7 @@ class BookmarksScreen extends StatelessWidget {
                       title: Text(
                         AppLocalizations.of(context)!.pageWithNumber(p + 1),
                       ),
-                      onTap: () => Navigator.pop(context, p),
+                      onTap: () => context.pop(p),
                     );
                   },
                 );

--- a/lib/screens/history_screen.dart
+++ b/lib/screens/history_screen.dart
@@ -1,11 +1,11 @@
 import 'dart:io';
 
 import 'package:flutter/material.dart';
-import '../l10n/app_localizations.dart';
+import 'package:go_router/go_router.dart';
 
 import '../database/db_helper.dart';
+import '../l10n/app_localizations.dart';
 import '../models/book_model.dart';
-import 'reader_screen.dart';
 
 /// Lists books sorted by recent reading history.
 class HistoryScreen extends StatelessWidget {
@@ -130,12 +130,7 @@ class HistoryScreen extends StatelessWidget {
                     );
                   },
                 ),
-                onTap: () => Navigator.push(
-                  context,
-                  MaterialPageRoute(
-                    builder: (_) => ReaderScreen(book: book),
-                  ),
-                ),
+                onTap: () => context.push('/reader', extra: book),
               );
             },
           );

--- a/lib/screens/library_screen.dart
+++ b/lib/screens/library_screen.dart
@@ -3,19 +3,17 @@ import 'dart:io' show Platform;
 
 import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
-import '../l10n/app_localizations.dart';
-import '../database/db_helper.dart';
-import '../models/book_model.dart';
+import 'package:go_router/go_router.dart';
 
+import '../database/db_helper.dart';
 import '../import/importer.dart';
 import '../import/sync_service.dart';
+import '../l10n/app_localizations.dart';
+import '../models/book_model.dart';
 import 'package:file_selector/file_selector.dart';
 import 'package:path/path.dart' as p;
 import 'package:path_provider/path_provider.dart';
 import 'package:permission_handler/permission_handler.dart';
-import 'book_detail_screen.dart';
-import 'history_screen.dart';
-import 'reader_screen.dart';
 
 /// Displays the list of imported books.
 class LibraryScreen extends StatefulWidget {
@@ -50,10 +48,7 @@ class _LibraryScreenState extends State<LibraryScreen> {
   String _sortOrder = 'title';
 
   void _openHistory() {
-    Navigator.push(
-      context,
-      MaterialPageRoute(builder: (_) => HistoryScreen()),
-    );
+    context.push('/history');
   }
 
   @override
@@ -234,10 +229,7 @@ class _LibraryScreenState extends State<LibraryScreen> {
               itemBuilder: (context, index) {
                 final book = books[index];
                 return GestureDetector(
-                  onTap: () => Navigator.push(
-                    context,
-                    MaterialPageRoute(builder: (_) => ReaderScreen(book: book)),
-                  ),
+                  onTap: () => context.push('/reader', extra: book),
                   onLongPress: () => _confirmDelete(book),
                   child: GridTile(
                     child: Stack(
@@ -400,10 +392,7 @@ class _LibraryScreenState extends State<LibraryScreen> {
                       ),
                     ],
                   ),
-                  onTap: () => Navigator.push(
-                    context,
-                    MaterialPageRoute(builder: (_) => ReaderScreen(book: book)),
-                  ),
+                  onTap: () => context.push('/reader', extra: book),
                   onLongPress: () => _confirmDelete(book),
                 );
               },
@@ -550,11 +539,11 @@ class _LibraryScreenState extends State<LibraryScreen> {
         content: Text(AppLocalizations.of(context)!.deleteConfirm(book.title)),
         actions: [
           TextButton(
-            onPressed: () => Navigator.pop(context, false),
+            onPressed: () => context.pop(false),
             child: Text(AppLocalizations.of(context)!.cancel),
           ),
           TextButton(
-            onPressed: () => Navigator.pop(context, true),
+            onPressed: () => context.pop(true),
             child: Text(AppLocalizations.of(context)!.delete),
           ),
         ],
@@ -568,10 +557,7 @@ class _LibraryScreenState extends State<LibraryScreen> {
   }
 
   Future<void> _openDetails(BookModel book) async {
-    await Navigator.push(
-      context,
-      MaterialPageRoute(builder: (_) => BookDetailScreen(book: book)),
-    );
+    await context.push('/book', extra: book);
     if (mounted) _loadBooks();
   }
 

--- a/lib/screens/main_menu.dart
+++ b/lib/screens/main_menu.dart
@@ -1,11 +1,9 @@
 import 'package:flutter/material.dart';
+import 'package:go_router/go_router.dart';
 
 import '../database/db_helper.dart';
-import '../models/book_model.dart';
 import '../l10n/app_localizations.dart';
-import 'history_screen.dart';
-import 'library_screen.dart';
-import 'reader_screen.dart';
+import '../models/book_model.dart';
 
 /// Simple start screen offering navigation to major sections.
 class MainMenu extends StatelessWidget {
@@ -34,29 +32,18 @@ class MainMenu extends StatelessWidget {
                 if (book != null)
                   ElevatedButton(
                     key: const Key('continue_reading_button'),
-                    onPressed: () => Navigator.push(
-                      context,
-                      MaterialPageRoute(
-                        builder: (_) => ReaderScreen(book: book),
-                      ),
-                    ),
+                    onPressed: () => context.push('/reader', extra: book),
                     child:
                         Text(AppLocalizations.of(context)!.continueReading),
                   ),
                 if (book != null) const SizedBox(height: 16),
                 ElevatedButton(
-                  onPressed: () => Navigator.push(
-                    context,
-                    MaterialPageRoute(builder: (_) => const LibraryScreen()),
-                  ),
+                  onPressed: () => context.push('/library'),
                   child: Text(AppLocalizations.of(context)!.library),
                 ),
                 const SizedBox(height: 16),
                 ElevatedButton(
-                  onPressed: () => Navigator.push(
-                    context,
-                    MaterialPageRoute(builder: (_) => HistoryScreen()),
-                  ),
+                  onPressed: () => context.push('/history'),
                   child: Text(AppLocalizations.of(context)!.history),
                 ),
               ],

--- a/lib/screens/reader_screen.dart
+++ b/lib/screens/reader_screen.dart
@@ -2,11 +2,11 @@ import 'dart:io';
 import 'dart:math';
 
 import 'package:flutter/material.dart';
-import '../l10n/app_localizations.dart';
+import 'package:go_router/go_router.dart';
 
 import '../database/db_helper.dart';
+import '../l10n/app_localizations.dart';
 import '../models/book_model.dart';
-import 'bookmarks_screen.dart';
 
 /// Displays the pages of a book using [PageView] and remembers the last page
 /// read. Supports left-to-right or right-to-left reading direction, pinch zoom
@@ -218,31 +218,23 @@ class _ReaderScreenState extends State<ReaderScreen> {
           if (next != null)
             TextButton(
               onPressed: () {
-                Navigator.pop(context);
-                Navigator.pushReplacement(
-                  context,
-                  MaterialPageRoute(builder: (_) => ReaderScreen(book: next!)),
-                );
+                context.pop();
+                context.pushReplacement('/reader', extra: next!);
               },
               child: Text(AppLocalizations.of(context)!.nextRelated),
             ),
           if (random != null)
             TextButton(
               onPressed: () {
-                Navigator.pop(context);
-                Navigator.pushReplacement(
-                  context,
-                  MaterialPageRoute(
-                    builder: (_) => ReaderScreen(book: random!),
-                  ),
-                );
+                context.pop();
+                context.pushReplacement('/reader', extra: random!);
               },
               child: Text(AppLocalizations.of(context)!.randomUnread),
             ),
           TextButton(
             onPressed: () {
-              Navigator.pop(context);
-              Navigator.pop(context);
+              context.pop();
+              context.pop();
             },
             child: Text(AppLocalizations.of(context)!.library),
           ),
@@ -252,10 +244,7 @@ class _ReaderScreenState extends State<ReaderScreen> {
   }
 
   Future<void> _openBookmarks() async {
-    final page = await Navigator.push<int>(
-      context,
-      MaterialPageRoute(builder: (_) => BookmarksScreen(book: _book)),
-    );
+    final page = await context.push<int>('/bookmarks', extra: _book);
     if (page != null && mounted) {
       final index = _doublePage ? (page / 2).floor() : page;
       _controller.jumpToPage(index);

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -135,6 +135,14 @@ packages:
     description: flutter
     source: sdk
     version: "0.0.0"
+  go_router:
+    dependency: "direct main"
+    description:
+      name: go_router
+      sha256: "6ad5662b014c06c20fa46ab78715c96b2222a7fe4f87bf77e0289592c2539e86"
+      url: "https://pub.dev"
+    source: hosted
+    version: "14.1.3"
   http:
     dependency: "direct main"
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -22,6 +22,7 @@ dependencies:
     sdk: flutter
   intl: ^0.20.2
   native_pdf_renderer: ^6.0.0
+  go_router: ^14.1.3
 
 
 

--- a/test/library_screen_test.dart
+++ b/test/library_screen_test.dart
@@ -7,6 +7,8 @@ import 'package:path_provider_platform_interface/path_provider_platform_interfac
 import 'package:mana_reader/models/book_model.dart';
 import 'package:mana_reader/screens/library_screen.dart';
 import 'package:mana_reader/database/db_helper.dart';
+import 'package:go_router/go_router.dart';
+import 'package:mana_reader/screens/book_detail_screen.dart';
 
 class _FakePathProviderPlatform extends PathProviderPlatform {
   final Directory tempDir =
@@ -93,10 +95,33 @@ void main() {
     final books = [
       BookModel(id: 1, title: 'E', path: '/tmp/e.cbz', language: 'en')
     ];
-    await tester.pumpWidget(MaterialApp(
-      home: LibraryScreen(
-          fetchBooks: ({tags, author, language, unread, favorite, query, orderBy}) async => books),
-    ));
+    final router = GoRouter(
+      routes: [
+        GoRoute(
+          path: '/',
+          builder: (context, state) => LibraryScreen(
+            fetchBooks: ({
+              tags,
+              author,
+              language,
+              unread,
+              favorite,
+              query,
+              orderBy,
+            }) async => books,
+          ),
+        ),
+        GoRoute(
+          path: '/book',
+          builder: (context, state) {
+            final book = state.extra as BookModel;
+            return BookDetailScreen(book: book);
+          },
+        ),
+      ],
+    );
+
+    await tester.pumpWidget(MaterialApp.router(routerConfig: router));
     await tester.pumpAndSettle();
 
     await tester.tap(find.byIcon(Icons.more_vert).first);

--- a/test/reader_screen_test.dart
+++ b/test/reader_screen_test.dart
@@ -9,6 +9,8 @@ import 'package:path/path.dart' as p;
 
 import 'package:mana_reader/models/book_model.dart';
 import 'package:mana_reader/screens/reader_screen.dart';
+import 'package:go_router/go_router.dart';
+import 'package:mana_reader/screens/bookmarks_screen.dart';
 
 void main() {
   testWidgets('displays book title and page view', (tester) async {
@@ -91,11 +93,23 @@ void main() {
     File(imgPath).writeAsBytesSync(base64Decode(
         'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8Xw8AAiMB7g6lbYkAAAAASUVORK5CYII='));
     final book = BookModel(title: 'Read', path: dir.path, language: 'en', pages: [imgPath]);
-    await tester.pumpWidget(MaterialApp(
-      localizationsDelegates: AppLocalizations.localizationsDelegates,
-      supportedLocales: AppLocalizations.supportedLocales,
-      home: ReaderScreen(book: book),
-    ));
+    final router = GoRouter(
+      routes: [
+        GoRoute(
+          path: '/',
+          builder: (context, state) => ReaderScreen(book: book),
+        ),
+        GoRoute(
+          path: '/bookmarks',
+          builder: (context, state) {
+            final b = state.extra as BookModel;
+            return BookmarksScreen(book: b);
+          },
+        ),
+      ],
+    );
+
+    await tester.pumpWidget(MaterialApp.router(routerConfig: router));
 
     await tester.tap(find.byIcon(Icons.more_vert));
     await tester.pumpAndSettle();


### PR DESCRIPTION
## Summary
- replace `MaterialApp` with `MaterialApp.router` using GoRouter
- enable Material 3 theme with seeded color scheme
- migrate navigation and tests to GoRouter API

## Testing
- `flutter analyze` *(fails: command not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68950b12f1d0832691a9002b071c58ec